### PR TITLE
Add tests for `std::optional` and `std::unique_ptr`

### DIFF
--- a/types/README.md
+++ b/types/README.md
@@ -1,6 +1,7 @@
 # Types
 
  * [`fundamental`](fundamental): fundamental column types
+ * [`optional`](optional): `std::optional` with different element types
  * [`string`](string): `std::string` with all `[Split]Index{32,64}` column types
  * [`variant`](variant): `std::variant` with `Switch` column type
  * [`vector`](vector): `std::vector` with all `[Split]Index{32,64}` column types

--- a/types/README.md
+++ b/types/README.md
@@ -3,5 +3,6 @@
  * [`fundamental`](fundamental): fundamental column types
  * [`optional`](optional): `std::optional` with different element types
  * [`string`](string): `std::string` with all `[Split]Index{32,64}` column types
+ * [`unique_ptr`](unique_ptr): `std::unique_ptr` with different element types
  * [`variant`](variant): `std::variant` with `Switch` column type
  * [`vector`](vector): `std::vector` with all `[Split]Index{32,64}` column types

--- a/types/optional/README.md
+++ b/types/optional/README.md
@@ -1,0 +1,18 @@
+# `std::optional`
+
+## Fields
+
+ * `[Split]Index{32,64}`: `std::optional<std::int32_t>`
+   * with the corresponding column type for the first (principal) column
+ * `String`: `std::optional<std::string>`
+ * `Variant`: `std::optional<std::variant<std::int32_t, std::string>>`
+ * `VectorInt32`: `std::optional<std::vector<std::int32_t>>`
+ * `VectorOpt`: `std::vector<std::optional<std::int32_t>>>`
+
+with otherwise the default column types.
+
+## Entries
+
+1. Simple values
+2. No value
+3. Zero / empty values

--- a/types/optional/read.C
+++ b/types/optional/read.C
@@ -1,0 +1,131 @@
+#include <ROOT/REntry.hxx>
+#include <ROOT/RNTupleReader.hxx>
+
+using ROOT::Experimental::REntry;
+using ROOT::Experimental::RNTupleReader;
+
+#include <cstdint>
+#include <fstream>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using VariantTy = std::variant<std::int32_t, std::string>;
+using VectorInt32Ty = std::vector<std::int32_t>;
+
+template <typename T> static void PrintValue(const T &value, std::ostream &os);
+
+template <> void PrintValue(const std::int32_t &value, std::ostream &os) {
+  os << value;
+}
+
+template <> void PrintValue(const std::string &value, std::ostream &os) {
+  os << "\"" << value << "\"";
+}
+
+template <> void PrintValue(const VariantTy &value, std::ostream &os) {
+  if (value.index() == 0) {
+    PrintValue(std::get<std::int32_t>(value), os);
+  } else if (value.index() == 1) {
+    PrintValue(std::get<std::string>(value), os);
+  }
+}
+
+template <> void PrintValue(const VectorInt32Ty &value, std::ostream &os) {
+  os << "[";
+  bool first = true;
+  for (auto element : value) {
+    if (first) {
+      first = false;
+    } else {
+      os << ",";
+    }
+    os << "\n      " << element;
+  }
+  if (!value.empty()) {
+    os << "\n    ";
+  }
+  os << "]";
+}
+
+template <typename T>
+static void PrintOptionalValue(const REntry &entry, std::string_view name,
+                               std::ostream &os, bool last = false) {
+  auto &value = *entry.GetPtr<std::optional<T>>(name);
+  os << "    \"" << name << "\": ";
+  if (!value.has_value()) {
+    os << "null";
+  } else {
+    PrintValue(*value, os);
+  }
+  if (!last) {
+    os << ",";
+  }
+  os << "\n";
+}
+
+static void PrintVectorOptValue(const REntry &entry, std::string_view name,
+                                std::ostream &os, bool last = false) {
+  auto &value = *entry.GetPtr<std::vector<std::optional<std::int32_t>>>(name);
+  os << "    \"" << name << "\": [";
+  bool first = true;
+  for (auto &&element : value) {
+    if (first) {
+      first = false;
+    } else {
+      os << ",";
+    }
+    os << "\n      ";
+    if (!element.has_value()) {
+      os << "null";
+    } else {
+      os << *element;
+    }
+  }
+  if (!value.empty()) {
+    os << "\n    ";
+  }
+  os << "]";
+  if (!last) {
+    os << ",";
+  }
+  os << "\n";
+}
+
+void read(std::string_view input = "types.optional.root",
+          std::string_view output = "types.optional.json") {
+  std::ofstream os(std::string{output});
+  os << "[\n";
+
+  auto reader = RNTupleReader::Open("ntpl", input);
+  auto &entry = reader->GetModel().GetDefaultEntry();
+  bool first = true;
+  for (auto index : *reader) {
+    reader->LoadEntry(index);
+
+    if (first) {
+      first = false;
+    } else {
+      os << ",\n";
+    }
+    os << "  {\n";
+
+    PrintOptionalValue<std::int32_t>(entry, "Index32", os);
+    PrintOptionalValue<std::int32_t>(entry, "Index64", os);
+    PrintOptionalValue<std::int32_t>(entry, "SplitIndex32", os);
+    PrintOptionalValue<std::int32_t>(entry, "SplitIndex64", os);
+    PrintOptionalValue<std::string>(entry, "String", os);
+    PrintOptionalValue<VariantTy>(entry, "Variant", os);
+    PrintOptionalValue<VectorInt32Ty>(entry, "VectorInt32", os);
+    PrintVectorOptValue(entry, "VectorOpt", os, /*last=*/true);
+
+    os << "  }";
+    // Newline is intentionally missing, may need to print a comma before the
+    // next entry.
+  }
+  os << "\n";
+  os << "]\n";
+}

--- a/types/optional/write.C
+++ b/types/optional/write.C
@@ -1,0 +1,91 @@
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+using ROOT::Experimental::EColumnType;
+using ROOT::Experimental::RField;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using OptInt32Ty = std::optional<std::int32_t>;
+using VariantTy = std::variant<std::int32_t, std::string>;
+using VectorInt32Ty = std::vector<std::int32_t>;
+
+static std::shared_ptr<OptInt32Ty> MakeIntField(RNTupleModel &model,
+                                                std::string_view name,
+                                                EColumnType indexType) {
+  auto field = std::make_unique<RField<OptInt32Ty>>(name);
+  field->SetColumnRepresentatives({{indexType}});
+  model.AddField(std::move(field));
+  return model.GetDefaultEntry().GetPtr<OptInt32Ty>(name);
+}
+
+void write(std::string_view filename = "types.optional.root") {
+  auto model = RNTupleModel::Create();
+
+  // Non-split index encoding
+  auto Index32 = MakeIntField(*model, "Index32", EColumnType::kIndex32);
+  auto Index64 = MakeIntField(*model, "Index64", EColumnType::kIndex64);
+
+  // Split index encoding
+  auto SplitIndex32 =
+      MakeIntField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+  auto SplitIndex64 =
+      MakeIntField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+
+  auto String = model->MakeField<std::optional<std::string>>("String");
+  auto Variant = model->MakeField<std::optional<VariantTy>>("Variant");
+  auto VectorInt32 =
+      model->MakeField<std::optional<VectorInt32Ty>>("VectorInt32");
+  auto VectorOpt =
+      model->MakeField<std::vector<std::optional<std::int32_t>>>("VectorOpt");
+
+  RNTupleWriteOptions options;
+  options.SetCompression(0);
+  auto writer =
+      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+
+  // First entry: simple values
+  *Index32 = 1;
+  *Index64 = 2;
+  *SplitIndex32 = 3;
+  *SplitIndex64 = 4;
+  *String = "abc";
+  *Variant = "def";
+  *VectorInt32 = {1, 2, 3};
+  *VectorOpt = {4, 5, 6};
+  writer->Fill();
+
+  // Second entry: no value
+  Index32->reset();
+  Index64->reset();
+  SplitIndex32->reset();
+  SplitIndex64->reset();
+  String->reset();
+  Variant->reset();
+  VectorInt32->reset();
+  *VectorOpt = {{}};
+  writer->Fill();
+
+  // Third entry: zero / empty value
+  *Index32 = 0;
+  *Index64 = 0;
+  *SplitIndex32 = 0;
+  *SplitIndex64 = 0;
+  *String = "";
+  *Variant = 0;
+  *VectorInt32 = VectorInt32Ty{};
+  *VectorOpt = {};
+  writer->Fill();
+}

--- a/types/unique_ptr/README.md
+++ b/types/unique_ptr/README.md
@@ -1,0 +1,18 @@
+# `std::unique_ptr`
+
+## Fields
+
+ * `[Split]Index{32,64}`: `std::unique_ptr<std::int32_t>`
+   * with the corresponding column type for the first (principal) column
+ * `String`: `std::unique_ptr<std::string>`
+ * `Variant`: `std::unique_ptr<std::variant<std::int32_t, std::string>>`
+ * `VectorInt32`: `std::unique_ptr<std::vector<std::int32_t>>`
+ * `VectorPtr`: `std::vector<std::unique_ptr<std::int32_t>>>`
+
+with otherwise the default column types.
+
+## Entries
+
+1. Simple values
+2. No value
+3. Zero / empty values

--- a/types/unique_ptr/read.C
+++ b/types/unique_ptr/read.C
@@ -1,0 +1,130 @@
+#include <ROOT/REntry.hxx>
+#include <ROOT/RNTupleReader.hxx>
+
+using ROOT::Experimental::REntry;
+using ROOT::Experimental::RNTupleReader;
+
+#include <cstdint>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using VariantTy = std::variant<std::int32_t, std::string>;
+using VectorInt32Ty = std::vector<std::int32_t>;
+
+template <typename T> static void PrintValue(const T &value, std::ostream &os);
+
+template <> void PrintValue(const std::int32_t &value, std::ostream &os) {
+  os << value;
+}
+
+template <> void PrintValue(const std::string &value, std::ostream &os) {
+  os << "\"" << value << "\"";
+}
+
+template <> void PrintValue(const VariantTy &value, std::ostream &os) {
+  if (value.index() == 0) {
+    PrintValue(std::get<std::int32_t>(value), os);
+  } else if (value.index() == 1) {
+    PrintValue(std::get<std::string>(value), os);
+  }
+}
+
+template <> void PrintValue(const VectorInt32Ty &value, std::ostream &os) {
+  os << "[";
+  bool first = true;
+  for (auto element : value) {
+    if (first) {
+      first = false;
+    } else {
+      os << ",";
+    }
+    os << "\n      " << element;
+  }
+  if (!value.empty()) {
+    os << "\n    ";
+  }
+  os << "]";
+}
+
+template <typename T>
+static void PrintUniquePtrValue(const REntry &entry, std::string_view name,
+                                std::ostream &os, bool last = false) {
+  auto &value = *entry.GetPtr<std::unique_ptr<T>>(name);
+  os << "    \"" << name << "\": ";
+  if (!value) {
+    os << "null";
+  } else {
+    PrintValue(*value, os);
+  }
+  if (!last) {
+    os << ",";
+  }
+  os << "\n";
+}
+
+static void PrintVectorPtrValue(const REntry &entry, std::string_view name,
+                                std::ostream &os, bool last = false) {
+  auto &value = *entry.GetPtr<std::vector<std::unique_ptr<std::int32_t>>>(name);
+  os << "    \"" << name << "\": [";
+  bool first = true;
+  for (auto &&element : value) {
+    if (first) {
+      first = false;
+    } else {
+      os << ",";
+    }
+    os << "\n      ";
+    if (!element) {
+      os << "null";
+    } else {
+      os << *element;
+    }
+  }
+  if (!value.empty()) {
+    os << "\n    ";
+  }
+  os << "]";
+  if (!last) {
+    os << ",";
+  }
+  os << "\n";
+}
+
+void read(std::string_view input = "types.unique_ptr.root",
+          std::string_view output = "types.unique_ptr.json") {
+  std::ofstream os(std::string{output});
+  os << "[\n";
+
+  auto reader = RNTupleReader::Open("ntpl", input);
+  auto &entry = reader->GetModel().GetDefaultEntry();
+  bool first = true;
+  for (auto index : *reader) {
+    reader->LoadEntry(index);
+
+    if (first) {
+      first = false;
+    } else {
+      os << ",\n";
+    }
+    os << "  {\n";
+
+    PrintUniquePtrValue<std::int32_t>(entry, "Index32", os);
+    PrintUniquePtrValue<std::int32_t>(entry, "Index64", os);
+    PrintUniquePtrValue<std::int32_t>(entry, "SplitIndex32", os);
+    PrintUniquePtrValue<std::int32_t>(entry, "SplitIndex64", os);
+    PrintUniquePtrValue<std::string>(entry, "String", os);
+    PrintUniquePtrValue<VariantTy>(entry, "Variant", os);
+    PrintUniquePtrValue<VectorInt32Ty>(entry, "VectorInt32", os);
+    PrintVectorPtrValue(entry, "VectorPtr", os, /*last=*/true);
+
+    os << "  }";
+    // Newline is intentionally missing, may need to print a comma before the
+    // next entry.
+  }
+  os << "\n";
+  os << "]\n";
+}

--- a/types/unique_ptr/write.C
+++ b/types/unique_ptr/write.C
@@ -1,0 +1,94 @@
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+using ROOT::Experimental::EColumnType;
+using ROOT::Experimental::RField;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using PtrInt32Ty = std::unique_ptr<std::int32_t>;
+using VariantTy = std::variant<std::int32_t, std::string>;
+using VectorInt32Ty = std::vector<std::int32_t>;
+
+static std::shared_ptr<PtrInt32Ty> MakeIntField(RNTupleModel &model,
+                                                std::string_view name,
+                                                EColumnType indexType) {
+  auto field = std::make_unique<RField<PtrInt32Ty>>(name);
+  field->SetColumnRepresentatives({{indexType}});
+  model.AddField(std::move(field));
+  return model.GetDefaultEntry().GetPtr<PtrInt32Ty>(name);
+}
+
+void write(std::string_view filename = "types.unique_ptr.root") {
+  auto model = RNTupleModel::Create();
+
+  // Non-split index encoding
+  auto Index32 = MakeIntField(*model, "Index32", EColumnType::kIndex32);
+  auto Index64 = MakeIntField(*model, "Index64", EColumnType::kIndex64);
+
+  // Split index encoding
+  auto SplitIndex32 =
+      MakeIntField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+  auto SplitIndex64 =
+      MakeIntField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+
+  auto String = model->MakeField<std::unique_ptr<std::string>>("String");
+  auto Variant = model->MakeField<std::unique_ptr<VariantTy>>("Variant");
+  auto VectorInt32 =
+      model->MakeField<std::unique_ptr<VectorInt32Ty>>("VectorInt32");
+  auto VectorPtr =
+      model->MakeField<std::vector<std::unique_ptr<std::int32_t>>>("VectorPtr");
+
+  RNTupleWriteOptions options;
+  options.SetCompression(0);
+  auto writer =
+      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+
+  // First entry: simple values
+  *Index32 = std::make_unique<std::int32_t>(1);
+  *Index64 = std::make_unique<std::int32_t>(2);
+  *SplitIndex32 = std::make_unique<std::int32_t>(3);
+  *SplitIndex64 = std::make_unique<std::int32_t>(4);
+  *String = std::make_unique<std::string>("abc");
+  *Variant = std::make_unique<VariantTy>("def");
+  *VectorInt32 = std::make_unique<VectorInt32Ty>();
+  **VectorInt32 = {1, 2, 3};
+  VectorPtr->push_back(std::make_unique<std::int32_t>(4));
+  VectorPtr->push_back(std::make_unique<std::int32_t>(5));
+  VectorPtr->push_back(std::make_unique<std::int32_t>(6));
+  writer->Fill();
+
+  // Second entry: no value
+  Index32->reset();
+  Index64->reset();
+  SplitIndex32->reset();
+  SplitIndex64->reset();
+  String->reset();
+  Variant->reset();
+  VectorInt32->reset();
+  VectorPtr->clear();
+  VectorPtr->push_back(nullptr);
+  writer->Fill();
+
+  // Third entry: zero / empty value
+  *Index32 = std::make_unique<std::int32_t>(0);
+  *Index64 = std::make_unique<std::int32_t>(0);
+  *SplitIndex32 = std::make_unique<std::int32_t>(0);
+  *SplitIndex64 = std::make_unique<std::int32_t>(0);
+  *String = std::make_unique<std::string>("");
+  *Variant = std::make_unique<VariantTy>(0);
+  *VectorInt32 = std::make_unique<VectorInt32Ty>();
+  VectorPtr->clear();
+  writer->Fill();
+}


### PR DESCRIPTION
 * `std::optional` (closes #15)
 * `std::unique_ptr` (closes #16)

---

I think that it's not really needed to test all `[Split]Index{32,64}` column types for these; let me know if you disagree.