### PR TITLE
Fix sorting of nested `unordered_multiset`

### DIFF
--- a/types/unordered_multiset/nested/read.C
+++ b/types/unordered_multiset/nested/read.C
@@ -32,7 +32,9 @@ static void PrintNestedUnorderedMultisetValue(const REntry &entry,
     std::vector innerSorted(inner.begin(), inner.end());
     std::sort(innerSorted.begin(), innerSorted.end());
     valueSorted.push_back(innerSorted);
-}
+  }
+
+  std::sort(valueSorted.begin(), valueSorted.end());
 
   os << "    \"" << name << "\": [";
   bool outerFirst = true;

--- a/types/unordered_multiset/nested/read.C
+++ b/types/unordered_multiset/nested/read.C
@@ -23,8 +23,6 @@ static void PrintNestedUnorderedMultisetValue(const REntry &entry,
                                               bool last = false) {
   UnorderedMultiset &value = *entry.GetPtr<UnorderedMultiset>(name);
 
-  std::vector<UnorderedMultiset::value_type> valueInnerSorted(value.begin(),
-                                                              value.end());
   std::vector<std::vector<UnorderedMultiset::value_type::value_type>>
       valueSorted;
 

--- a/types/unordered_set/nested/read.C
+++ b/types/unordered_set/nested/read.C
@@ -21,8 +21,6 @@ static void PrintNestedUnorderedSetValue(const REntry &entry,
                                          std::ostream &os, bool last = false) {
   UnorderedSet &value = *entry.GetPtr<UnorderedSet>(name);
 
-  std::vector<UnorderedSet::value_type> valueInnerSorted(
-      value.begin(), value.end());
   std::vector<std::vector<UnorderedSet::value_type::value_type>> valueSorted;
 
   for (auto inner : value) {


### PR DESCRIPTION
The outer container must be sorted, as already done for nested `unordered_set`.