### PR TITLE
Include `TSystem.h` in `types/user/enum/read.C`

### DIFF
--- a/types/user/enum/read.C
+++ b/types/user/enum/read.C
@@ -4,6 +4,8 @@
 using ROOT::Experimental::REntry;
 using ROOT::Experimental::RNTupleReader;
 
+#include <TSystem.h>
+
 #include <cstdint>
 #include <fstream>
 #include <ostream>


### PR DESCRIPTION
It needs to load the dictionary using `gSystem`.