### PR TITLE
Switch to stable API in ROOT 6.36

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -5,10 +5,10 @@ on:
   pull_request:
 
 jobs:
-  root-v634:
-    name: ROOT 6.34
+  root-v636:
+    name: ROOT 6.36
     runs-on: ubuntu-latest
-    container: rootproject/root:6.34.00-ubuntu24.04
+    container: rootproject/root:6.36.00-ubuntu25.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ More tests are planned in the future, please [consult the list of issues](https:
 ## Reference Implementation
 
 This repository also contains a reference implementation with ROOT macros.
-They currently target ROOT v6.34 with the first official version of the RNTuple on-disk binary format.
-In this release, the API is not yet finalized and all classes are in the `ROOT::Experimental` namespace.
-We rely on this version to produce a first set of reference files that can be used to test backwards compatibility.
-Afterwards, the implementation will be updated for the stable API (available since ROOT v6.36).
+They target the stable API released with ROOT v6.36 and should work on newer versions.
+Compatibility with ROOT v6.34 can be tested with version v1.0 of the RNTuple Validation Suite.
+It was the first official version of the RNTuple on-disk binary format, but the API was not yet finalized and all classes were in the `ROOT::Experimental` namespace.
 
 ### How to Run
 

--- a/compression/algorithms/write_algorithm.hxx
+++ b/compression/algorithms/write_algorithm.hxx
@@ -3,10 +3,10 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -17,7 +17,7 @@ void write_algorithm(std::string_view filename, std::uint32_t compression) {
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{EColumnType::kSplitInt64}});
+      {{ENTupleColumnType::kSplitInt64}});
 
   RNTupleWriteOptions options;
   options.SetCompression(compression);

--- a/compression/algorithms/write_algorithm.hxx
+++ b/compression/algorithms/write_algorithm.hxx
@@ -1,5 +1,9 @@
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/compression/algorithms/write_algorithm.hxx
+++ b/compression/algorithms/write_algorithm.hxx
@@ -3,26 +3,21 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
 
 void write_algorithm(std::string_view filename, std::uint32_t compression) {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{ENTupleColumnType::kSplitInt64}});
+      {{ROOT::ENTupleColumnType::kSplitInt64}});
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(compression);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // Write 32 entries to make sure the compression block is not too small.
   for (int i = 0; i < 32; i++) {

--- a/compression/block/big/write.C
+++ b/compression/block/big/write.C
@@ -3,10 +3,10 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -17,7 +17,7 @@ void write(std::string_view filename = "compression.block.big.root") {
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{EColumnType::kSplitInt64}});
+      {{ENTupleColumnType::kSplitInt64}});
 
   RNTupleWriteOptions options;
   // Crank up the zstd compression level to reduce the output file size by

--- a/compression/block/big/write.C
+++ b/compression/block/big/write.C
@@ -1,5 +1,9 @@
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/compression/block/big/write.C
+++ b/compression/block/big/write.C
@@ -3,31 +3,26 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
 
 void write(std::string_view filename = "compression.block.big.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{ENTupleColumnType::kSplitInt64}});
+      {{ROOT::ENTupleColumnType::kSplitInt64}});
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   // Crank up the zstd compression level to reduce the output file size by
   // approximately a factor 6 (from 76K with 505 to 12K).
   options.SetCompression(509);
   // Increase the maximum unzipped page size to make it bigger than the maximum
   // size of a compression block, which is 16 MiB.
   options.SetMaxUnzippedPageSize(128 * 1024 * 1024);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // Write 40 MiB of entries that will be split into three compression blocks.
   static constexpr int Entries = 40 * 1024 * 1024 / sizeof(std::int64_t);

--- a/compression/block/short/write.C
+++ b/compression/block/short/write.C
@@ -3,26 +3,21 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
 
 void write(std::string_view filename = "compression.block.short.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{ENTupleColumnType::kSplitInt64}});
+      {{ROOT::ENTupleColumnType::kSplitInt64}});
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(505);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // Write only 2 entries to make sure the compression block is small and
   // actually stored uncompressed.

--- a/compression/block/short/write.C
+++ b/compression/block/short/write.C
@@ -1,5 +1,9 @@
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/compression/block/short/write.C
+++ b/compression/block/short/write.C
@@ -3,10 +3,10 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -17,7 +17,7 @@ void write(std::string_view filename = "compression.block.short.root") {
 
   auto Int64 = model->MakeField<std::int64_t>("Int64");
   model->GetMutableField("Int64").SetColumnRepresentatives(
-      {{EColumnType::kSplitInt64}});
+      {{ENTupleColumnType::kSplitInt64}});
 
   RNTupleWriteOptions options;
   options.SetCompression(505);

--- a/compression/read_compression.hxx
+++ b/compression/read_compression.hxx
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 void read_compression(std::string_view input, std::string_view output) {
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto Int64 =
       reader->GetModel().GetDefaultEntry().GetPtr<std::int64_t>("Int64");
   std::int64_t sum = 0;

--- a/compression/read_compression.hxx
+++ b/compression/read_compression.hxx
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/projections/cardinality/read.C
+++ b/projections/cardinality/read.C
@@ -1,6 +1,10 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 
 #include <cstdint>
 #include <fstream>

--- a/projections/cardinality/read.C
+++ b/projections/cardinality/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -14,7 +11,7 @@ using ROOT::RNTupleReader;
 
 using Vector = std::vector<std::int32_t>;
 
-static void PrintVectorValue(const REntry &entry, std::string_view name,
+static void PrintVectorValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
@@ -38,7 +35,7 @@ static void PrintVectorValue(const REntry &entry, std::string_view name,
 }
 
 template <typename T>
-static void PrintCardinality(const REntry &entry, std::string_view name,
+static void PrintCardinality(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<ROOT::RNTupleCardinality<T>>(name);
   os << "    \"" << name << "\": " << value;
@@ -53,7 +50,7 @@ void read(std::string_view input = "projections.cardinality.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/projections/cardinality/read.C
+++ b/projections/cardinality/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/projections/cardinality/write.C
+++ b/projections/cardinality/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/projections/cardinality/write.C
+++ b/projections/cardinality/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -18,37 +12,40 @@ using ROOT::RNTupleWriter;
 
 using Vector = std::vector<std::int32_t>;
 
-static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
-                                               std::string_view name,
-                                               ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Vector>>(name);
+static std::shared_ptr<Vector>
+MakeVectorField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Vector>(name);
 }
 
 template <typename T>
-static void AddProjectedCardinalityField(RNTupleModel &model,
+static void AddProjectedCardinalityField(ROOT::RNTupleModel &model,
                                          std::string_view name,
                                          std::string_view source) {
-  auto field = std::make_unique<RField<ROOT::RNTupleCardinality<T>>>(name);
+  auto field =
+      std::make_unique<ROOT::RField<ROOT::RNTupleCardinality<T>>>(name);
   model.AddProjectedField(std::move(field), [&source](const std::string &) {
     return std::string{source};
   });
 }
 
 void write(std::string_view filename = "projections.cardinality.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeVectorField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeVectorField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeVectorField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeVectorField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
   // Create RNTupleCardinality projections
   AddProjectedCardinalityField<std::uint32_t>(*model, "Index32Cardinality",
@@ -60,10 +57,10 @@ void write(std::string_view filename = "projections.cardinality.root") {
   AddProjectedCardinalityField<std::uint64_t>(*model, "SplitIndex64Cardinality",
                                               "SplitIndex64");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element vectors, with ascending values
   *Index32 = {1};

--- a/projections/cardinality/write.C
+++ b/projections/cardinality/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -20,7 +20,7 @@ using Vector = std::vector<std::int32_t>;
 
 static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType indexType) {
+                                               ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -41,14 +41,14 @@ void write(std::string_view filename = "projections.cardinality.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   // Create RNTupleCardinality projections
   AddProjectedCardinalityField<std::uint32_t>(*model, "Index32Cardinality",

--- a/projections/collection/read.C
+++ b/projections/collection/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/projections/collection/read.C
+++ b/projections/collection/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,8 +10,9 @@ using ROOT::RNTupleReader;
 #include <vector>
 
 template <typename C>
-static void PrintCollectionValue(const REntry &entry, std::string_view name,
-                                 std::ostream &os, bool last = false) {
+static void PrintCollectionValue(const ROOT::REntry &entry,
+                                 std::string_view name, std::ostream &os,
+                                 bool last = false) {
   C &value = *entry.GetPtr<C>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -41,7 +39,7 @@ void read(std::string_view input = "projections.collection.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/projections/collection/write.C
+++ b/projections/collection/write.C
@@ -4,10 +4,10 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>

--- a/projections/collection/write.C
+++ b/projections/collection/write.C
@@ -4,11 +4,6 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -16,11 +11,11 @@ using ROOT::RNTupleWriter;
 #include <vector>
 
 void write(std::string_view filename = "projections.collection.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Vector = model->MakeField<std::vector<std::int32_t>>("Vector");
   auto Projected =
-      std::make_unique<RField<ROOT::RVec<std::int32_t>>>("Projected");
+      std::make_unique<ROOT::RField<ROOT::RVec<std::int32_t>>>("Projected");
   model->AddProjectedField(std::move(Projected),
                            [](const std::string &fieldName) {
                              if (fieldName == "Projected") {
@@ -30,10 +25,10 @@ void write(std::string_view filename = "projections.collection.root") {
                              }
                            });
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *Vector = {1, 2};

--- a/projections/leaf/read.C
+++ b/projections/leaf/read.C
@@ -1,6 +1,5 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
-#include <ROOT/RNTupleUtil.hxx>
 
 #include <cstdint>
 #include <fstream>

--- a/projections/leaf/read.C
+++ b/projections/leaf/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -23,7 +20,7 @@ template <> void PrintValue(const float &value, std::ostream &os) {
 }
 
 template <typename T, typename U>
-static void PrintPairValue(const REntry &entry, std::string_view name,
+static void PrintPairValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::pair<T, U>>(name);
   os << "    \"" << name << "\": [\n";
@@ -41,7 +38,7 @@ static void PrintPairValue(const REntry &entry, std::string_view name,
 }
 
 template <typename T>
-static void PrintValue(const REntry &entry, std::string_view name,
+static void PrintValue(const ROOT::REntry &entry, std::string_view name,
                        std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": ";
@@ -59,7 +56,7 @@ void read(std::string_view input = "projections.leaf.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/projections/leaf/read.C
+++ b/projections/leaf/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/projections/leaf/write.C
+++ b/projections/leaf/write.C
@@ -3,11 +3,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -15,25 +10,25 @@ using ROOT::RNTupleWriter;
 #include <utility>
 
 template <typename T>
-static void AddProjectedField(RNTupleModel &model, std::string_view name,
+static void AddProjectedField(ROOT::RNTupleModel &model, std::string_view name,
                               std::string_view source) {
-  auto field = std::make_unique<RField<T>>(name);
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   model.AddProjectedField(std::move(field), [&source](const std::string &) {
     return std::string{source};
   });
 }
 
 void write(std::string_view filename = "projections.leaf.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Pair = model->MakeField<std::pair<std::int32_t, float>>("Pair");
   AddProjectedField<std::int32_t>(*model, "Int32", "Pair._0");
   AddProjectedField<float>(*model, "Float", "Pair._1");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *Pair = {1, 2.0};

--- a/projections/leaf/write.C
+++ b/projections/leaf/write.C
@@ -3,10 +3,10 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>

--- a/projections/nested/read.C
+++ b/projections/nested/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/projections/nested/read.C
+++ b/projections/nested/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -36,7 +33,7 @@ void PrintValue(const std::pair<std::int32_t, float> &value, std::ostream &os) {
 }
 
 template <typename T>
-static void PrintVectorValue(const REntry &entry, std::string_view name,
+static void PrintVectorValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::vector<T>>(name);
   os << "    \"" << name << "\": [";
@@ -67,7 +64,7 @@ void read(std::string_view input = "projections.nested.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/projections/nested/write.C
+++ b/projections/nested/write.C
@@ -4,10 +4,10 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>

--- a/projections/nested/write.C
+++ b/projections/nested/write.C
@@ -4,11 +4,6 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -17,9 +12,9 @@ using ROOT::RNTupleWriter;
 #include <vector>
 
 template <typename T>
-static void AddProjectedField(RNTupleModel &model, std::string_view name,
+static void AddProjectedField(ROOT::RNTupleModel &model, std::string_view name,
                               std::string_view source) {
-  auto field = std::make_unique<RField<std::vector<T>>>(name);
+  auto field = std::make_unique<ROOT::RField<std::vector<T>>>(name);
   model.AddProjectedField(std::move(field),
                           [&name, &source](const std::string &fieldName) {
                             if (fieldName == name) {
@@ -31,7 +26,7 @@ static void AddProjectedField(RNTupleModel &model, std::string_view name,
 }
 
 void write(std::string_view filename = "projections.nested.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto VectorPair =
       model->MakeField<std::vector<std::pair<std::int32_t, float>>>(
@@ -39,10 +34,10 @@ void write(std::string_view filename = "projections.nested.root") {
   AddProjectedField<std::int32_t>(*model, "VectorInt", "_0");
   AddProjectedField<float>(*model, "VectorFloat", "_1");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   VectorPair->emplace_back(1, 2.0);

--- a/structure/cluster_groups/write.C
+++ b/structure/cluster_groups/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <string_view>

--- a/structure/cluster_groups/write.C
+++ b/structure/cluster_groups/write.C
@@ -2,22 +2,18 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <string_view>
 
 void write(std::string_view filename = "structure.cluster_groups.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int32 = model->MakeField<std::int32_t>("Int32");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   *Int32 = 1;
   writer->Fill();

--- a/structure/clusters/write.C
+++ b/structure/clusters/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <string_view>

--- a/structure/clusters/write.C
+++ b/structure/clusters/write.C
@@ -2,22 +2,18 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <string_view>
 
 void write(std::string_view filename = "structure.clusters.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int32 = model->MakeField<std::int32_t>("Int32");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   *Int32 = 1;
   writer->Fill();

--- a/structure/empty/write.C
+++ b/structure/empty/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <string_view>

--- a/structure/empty/write.C
+++ b/structure/empty/write.C
@@ -2,22 +2,18 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <string_view>
 
 void write(std::string_view filename = "structure.empty.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int32 = model->MakeField<std::int32_t>("Int32");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // Destruct the writer / commit the dataset without filling an entry.
   writer.reset();

--- a/structure/feature_flag/write.C
+++ b/structure/feature_flag/write.C
@@ -8,13 +8,13 @@
 #include <string_view>
 #include <utility>
 
-using ROOT::Experimental::RFieldZero;
-using ROOT::Experimental::RNTupleDescriptor;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::Internal::RFieldDescriptorBuilder;
-using ROOT::Experimental::Internal::RNTupleDescriptorBuilder;
-using ROOT::Experimental::Internal::RNTupleFileWriter;
-using ROOT::Experimental::Internal::RNTupleSerializer;
+using ROOT::RFieldZero;
+using ROOT::RNTupleDescriptor;
+using ROOT::RNTupleWriteOptions;
+using ROOT::Internal::RFieldDescriptorBuilder;
+using ROOT::Internal::RNTupleDescriptorBuilder;
+using ROOT::Internal::RNTupleFileWriter;
+using ROOT::Internal::RNTupleSerializer;
 
 void write(std::string_view filename = "structure.feature_flag.root") {
   // Note that we are writing a file with a so-far unused feature flag. This
@@ -40,13 +40,13 @@ void write(std::string_view filename = "structure.feature_flag.root") {
 
   RNTupleSerializer serializer;
 
-  auto ctx = serializer.SerializeHeader(nullptr, descriptor);
+  auto ctx = serializer.SerializeHeader(nullptr, descriptor).Unwrap();
   auto buffer = std::make_unique<unsigned char[]>(ctx.GetHeaderSize());
-  ctx = serializer.SerializeHeader(buffer.get(), descriptor);
+  ctx = serializer.SerializeHeader(buffer.get(), descriptor).Unwrap();
   writer->WriteNTupleHeader(buffer.get(), ctx.GetHeaderSize(),
                             ctx.GetHeaderSize());
 
-  auto szFooter = serializer.SerializeFooter(nullptr, descriptor, ctx);
+  auto szFooter = serializer.SerializeFooter(nullptr, descriptor, ctx).Unwrap();
   buffer = std::make_unique<unsigned char[]>(szFooter);
   serializer.SerializeFooter(buffer.get(), descriptor, ctx);
   writer->WriteNTupleFooter(buffer.get(), szFooter, szFooter);

--- a/structure/feature_flag/write.C
+++ b/structure/feature_flag/write.C
@@ -8,9 +8,6 @@
 #include <string_view>
 #include <utility>
 
-using ROOT::RFieldZero;
-using ROOT::RNTupleDescriptor;
-using ROOT::RNTupleWriteOptions;
 using ROOT::Internal::RFieldDescriptorBuilder;
 using ROOT::Internal::RNTupleDescriptorBuilder;
 using ROOT::Internal::RNTupleFileWriter;
@@ -25,14 +22,14 @@ void write(std::string_view filename = "structure.feature_flag.root") {
   // The following line will be required as of ROOT v6.36
   // descBuilder.SetVersionForWriting();
   descBuilder.SetNTuple("ntpl", "");
-  descBuilder.SetFeature(RNTupleDescriptor::kFeatureFlagTest);
-  descBuilder.AddField(RFieldDescriptorBuilder::FromField(RFieldZero())
+  descBuilder.SetFeature(ROOT::RNTupleDescriptor::kFeatureFlagTest);
+  descBuilder.AddField(RFieldDescriptorBuilder::FromField(ROOT::RFieldZero())
                            .FieldId(0)
                            .MakeDescriptor()
                            .Unwrap());
   auto descriptor = descBuilder.MoveDescriptor();
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
   auto writer = RNTupleFileWriter::Recreate(
       "ntpl", filename, RNTupleFileWriter::EContainerFormat::kTFile,

--- a/structure/feature_flag/write.C
+++ b/structure/feature_flag/write.C
@@ -3,6 +3,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RVersion.hxx>
 
 #include <memory>
 #include <string_view>
@@ -19,8 +20,9 @@ void write(std::string_view filename = "structure.feature_flag.root") {
   // low-level classes to create the file.
 
   RNTupleDescriptorBuilder descBuilder;
-  // The following line will be required as of ROOT v6.36
-  // descBuilder.SetVersionForWriting();
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 36, 4)
+  descBuilder.SetVersionForWriting();
+#endif
   descBuilder.SetNTuple("ntpl", "");
   descBuilder.SetFeature(ROOT::RNTupleDescriptor::kFeatureFlagTest);
   descBuilder.AddField(RFieldDescriptorBuilder::FromField(ROOT::RFieldZero())

--- a/structure/feature_flag/write.C
+++ b/structure/feature_flag/write.C
@@ -48,7 +48,7 @@ void write(std::string_view filename = "structure.feature_flag.root") {
   serializer.SerializeFooter(buffer.get(), descriptor, ctx);
   writer->WriteNTupleFooter(buffer.get(), szFooter, szFooter);
 
-  writer->Commit();
+  writer->Commit(options.GetCompression());
   // Call destructor to flush data to disk
   writer.reset();
 }

--- a/structure/read_structure.hxx
+++ b/structure/read_structure.hxx
@@ -2,8 +2,8 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::RException;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::RException;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/structure/read_structure.hxx
+++ b/structure/read_structure.hxx
@@ -2,9 +2,6 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::RException;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -14,10 +11,10 @@ using ROOT::RNTupleReader;
 void read_structure(std::string_view input, std::string_view output) {
   std::ofstream os(std::string{output});
 
-  std::unique_ptr<RNTupleReader> reader;
+  std::unique_ptr<ROOT::RNTupleReader> reader;
   try {
-    reader = RNTupleReader::Open("ntpl", input);
-  } catch (const RException &e) {
+    reader = ROOT::RNTupleReader::Open("ntpl", input);
+  } catch (const ROOT::RException &e) {
     std::string msgWithoutStacktrace;
     std::getline(std::istringstream(e.what()), msgWithoutStacktrace);
     os << "{\n";

--- a/types/RVec/fundamental/read.C
+++ b/types/RVec/fundamental/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/RVec/fundamental/read.C
+++ b/types/RVec/fundamental/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using Vector = ROOT::RVec<std::int32_t>;
 
-static void PrintVectorValue(const REntry &entry, std::string_view name,
+static void PrintVectorValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.RVec.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/RVec/fundamental/write.C
+++ b/types/RVec/fundamental/write.C
@@ -5,44 +5,40 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
 
 using Vector = ROOT::RVec<std::int32_t>;
 
-static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
-                                               std::string_view name,
-                                               ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Vector>>(name);
+static std::shared_ptr<Vector>
+MakeVectorField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Vector>(name);
 }
 
 void write(std::string_view filename = "types.RVec.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeVectorField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeVectorField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeVectorField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeVectorField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element vectors, with ascending values
   *Index32 = {1};

--- a/types/RVec/fundamental/write.C
+++ b/types/RVec/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>

--- a/types/RVec/fundamental/write.C
+++ b/types/RVec/fundamental/write.C
@@ -5,11 +5,11 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using Vector = ROOT::RVec<std::int32_t>;
 
 static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType indexType) {
+                                               ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.RVec.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/RVec/nested/read.C
+++ b/types/RVec/nested/read.C
@@ -2,8 +2,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/RVec/nested/read.C
+++ b/types/RVec/nested/read.C
@@ -2,9 +2,6 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,8 +10,9 @@ using ROOT::RNTupleReader;
 
 using Vector = ROOT::RVec<ROOT::RVec<std::int32_t>>;
 
-static void PrintNestedVectorValue(const REntry &entry, std::string_view name,
-                                   std::ostream &os, bool last = false) {
+static void PrintNestedVectorValue(const ROOT::REntry &entry,
+                                   std::string_view name, std::ostream &os,
+                                   bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
   bool outerFirst = true;
@@ -54,7 +52,7 @@ void read(std::string_view input = "types.RVec.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/RVec/nested/write.C
+++ b/types/RVec/nested/write.C
@@ -62,11 +62,4 @@ void write(std::string_view filename = "types.RVec.nested.root") {
   *SplitIndex32 = {{4}, {}, {5, 6}};
   *SplitIndex64 = {{}, {7, 8, 9}, {}, {10}};
   writer->Fill();
-
-  // Work around bug in 6.34 for destroying RVec's, later fixed by commit
-  // https://github.com/root-project/root/commit/996cac359d for 6.36.
-  Index32->clear();
-  Index64->clear();
-  SplitIndex32->clear();
-  SplitIndex64->clear();
 }

--- a/types/RVec/nested/write.C
+++ b/types/RVec/nested/write.C
@@ -5,11 +5,11 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -20,10 +20,10 @@ using Vector = ROOT::RVec<Inner>;
 
 static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType indexType) {
+                                               ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Vector>(name);
 }
@@ -32,14 +32,14 @@ void write(std::string_view filename = "types.RVec.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/RVec/nested/write.C
+++ b/types/RVec/nested/write.C
@@ -5,12 +5,6 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -18,10 +12,10 @@ using ROOT::RNTupleWriter;
 using Inner = ROOT::RVec<std::int32_t>;
 using Vector = ROOT::RVec<Inner>;
 
-static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
-                                               std::string_view name,
-                                               ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Vector>>(name);
+static std::shared_ptr<Vector>
+MakeVectorField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -29,22 +23,24 @@ static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
 }
 
 void write(std::string_view filename = "types.RVec.nested.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeVectorField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeVectorField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeVectorField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeVectorField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element vectors, with ascending values
   *Index32 = {{1}};

--- a/types/RVec/nested/write.C
+++ b/types/RVec/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RVec.hxx>

--- a/types/array/read.C
+++ b/types/array/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <array>
 #include <cstdint>
 #include <fstream>
@@ -54,7 +51,7 @@ template <> void PrintValue(const VectorInt32 &value, std::ostream &os) {
 }
 
 template <typename T>
-static void PrintArrayValue(const REntry &entry, std::string_view name,
+static void PrintArrayValue(const ROOT::REntry &entry, std::string_view name,
                             std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::array<T, 2>>(name);
   os << "    \"" << name << "\": [";
@@ -76,8 +73,9 @@ static void PrintArrayValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintArrayArrayValue(const REntry &entry, std::string_view name,
-                                 std::ostream &os, bool last = false) {
+static void PrintArrayArrayValue(const ROOT::REntry &entry,
+                                 std::string_view name, std::ostream &os,
+                                 bool last = false) {
   auto &value = *entry.GetPtr<std::array<std::array<std::int32_t, 2>, 3>>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -112,7 +110,7 @@ void read(std::string_view input = "types.array.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/array/read.C
+++ b/types/array/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <array>
 #include <cstdint>

--- a/types/array/write.C
+++ b/types/array/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -20,7 +16,7 @@ using Variant = std::variant<std::int32_t, std::string>;
 using VectorInt32 = std::vector<std::int32_t>;
 
 void write(std::string_view filename = "types.array.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Array_Int32 = model->MakeField<ArrayInt32>("Array_Int32");
   auto Array_Array = model->MakeField<std::array<ArrayInt32, 3>>("Array_Array");
@@ -31,10 +27,10 @@ void write(std::string_view filename = "types.array.root") {
   auto Array_Vector =
       model->MakeField<std::array<VectorInt32, 2>>("Array_Vector");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *Array_Int32 = {1, 2};

--- a/types/array/write.C
+++ b/types/array/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <array>
 #include <cstdint>

--- a/types/atomic/read.C
+++ b/types/atomic/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <atomic>
 #include <cstddef> // for std::byte

--- a/types/atomic/read.C
+++ b/types/atomic/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <atomic>
 #include <cstddef> // for std::byte
 #include <cstdint>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintIntegerValue(const REntry &entry, std::string_view name,
+static void PrintIntegerValue(const ROOT::REntry &entry, std::string_view name,
                               std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<std::atomic<T>>(name);
   os << "    \"" << name << "\": ";
@@ -27,7 +24,7 @@ static void PrintIntegerValue(const REntry &entry, std::string_view name,
 }
 
 template <typename T>
-static void PrintRealValue(const REntry &entry, std::string_view name,
+static void PrintRealValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<std::atomic<T>>(name);
   os << "    \"" << name << "\": \"" << value << "\"";
@@ -44,7 +41,7 @@ void read(std::string_view input = "types.atomic.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/atomic/write.C
+++ b/types/atomic/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <atomic>
 #include <cstddef> // for std::byte
 #include <cstdint>
@@ -13,13 +9,13 @@ using ROOT::RNTupleWriter;
 #include <string_view>
 
 template <typename T>
-static std::shared_ptr<std::atomic<T>> MakeAtomicField(RNTupleModel &model,
-                                                       std::string_view name) {
+static std::shared_ptr<std::atomic<T>>
+MakeAtomicField(ROOT::RNTupleModel &model, std::string_view name) {
   return model.MakeField<std::atomic<T>>(name);
 }
 
 void write(std::string_view filename = "types.atomic.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Bit = MakeAtomicField<bool>(*model, "Bit");
   auto Byte = MakeAtomicField<std::byte>(*model, "Byte");
@@ -37,10 +33,10 @@ void write(std::string_view filename = "types.atomic.root") {
   auto Real32 = MakeAtomicField<float>(*model, "Real32");
   auto Real64 = MakeAtomicField<double>(*model, "Real64");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *Bit = 1;

--- a/types/atomic/write.C
+++ b/types/atomic/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <atomic>
 #include <cstddef> // for std::byte

--- a/types/bitset/read.C
+++ b/types/bitset/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <bitset>
 #include <cstddef>

--- a/types/bitset/read.C
+++ b/types/bitset/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <bitset>
 #include <cstddef>
 #include <fstream>
@@ -12,7 +9,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <std::size_t N>
-static void PrintBitsetValue(const REntry &entry, std::string_view name,
+static void PrintBitsetValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::bitset<N>>(name);
   os << "    \"" << name << "\": \"" << value.to_string() << "\"";
@@ -27,7 +24,7 @@ void read(std::string_view input = "types.bitset.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/bitset/write.C
+++ b/types/bitset/write.C
@@ -2,25 +2,21 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <bitset>
 #include <memory>
 #include <string_view>
 
 void write(std::string_view filename = "types.bitset.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Bitset1 = model->MakeField<std::bitset<1>>("Bitset1");
   auto Bitset64 = model->MakeField<std::bitset<64>>("Bitset64");
   auto Bitset65 = model->MakeField<std::bitset<65>>("Bitset65");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending bits set
   Bitset1->set(0);

--- a/types/bitset/write.C
+++ b/types/bitset/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <bitset>
 #include <memory>

--- a/types/fundamental/integer/read.C
+++ b/types/fundamental/integer/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintIntegerValue(const REntry &entry, std::string_view name,
+static void PrintIntegerValue(const ROOT::REntry &entry, std::string_view name,
                               std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": ";
@@ -29,7 +26,7 @@ void read(std::string_view input = "types.fundamental.integer.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/fundamental/integer/read.C
+++ b/types/fundamental/integer/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/fundamental/integer/write.C
+++ b/types/fundamental/integer/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/fundamental/integer/write.C
+++ b/types/fundamental/integer/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <limits>
@@ -18,7 +18,7 @@ using ROOT::Experimental::RNTupleWriter;
 template <typename T>
 static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType type) {
+                                               ENTupleColumnType type) {
   auto field = std::make_unique<RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
@@ -29,37 +29,37 @@ void write(std::string_view filename = "types.fundamental.integer.root") {
   auto model = RNTupleModel::Create();
 
   auto Int8 =
-      MakeFundamentalField<std::int8_t>(*model, "Int8", EColumnType::kInt8);
+      MakeFundamentalField<std::int8_t>(*model, "Int8", ENTupleColumnType::kInt8);
   auto UInt8 =
-      MakeFundamentalField<std::uint8_t>(*model, "UInt8", EColumnType::kUInt8);
+      MakeFundamentalField<std::uint8_t>(*model, "UInt8", ENTupleColumnType::kUInt8);
 
   // Non-split integer encoding
   auto Int16 =
-      MakeFundamentalField<std::int16_t>(*model, "Int16", EColumnType::kInt16);
+      MakeFundamentalField<std::int16_t>(*model, "Int16", ENTupleColumnType::kInt16);
   auto UInt16 = MakeFundamentalField<std::uint16_t>(*model, "UInt16",
-                                                    EColumnType::kUInt16);
+                                                    ENTupleColumnType::kUInt16);
   auto Int32 =
-      MakeFundamentalField<std::int32_t>(*model, "Int32", EColumnType::kInt32);
+      MakeFundamentalField<std::int32_t>(*model, "Int32", ENTupleColumnType::kInt32);
   auto UInt32 = MakeFundamentalField<std::uint32_t>(*model, "UInt32",
-                                                    EColumnType::kUInt32);
+                                                    ENTupleColumnType::kUInt32);
   auto Int64 =
-      MakeFundamentalField<std::int64_t>(*model, "Int64", EColumnType::kInt64);
+      MakeFundamentalField<std::int64_t>(*model, "Int64", ENTupleColumnType::kInt64);
   auto UInt64 = MakeFundamentalField<std::uint64_t>(*model, "UInt64",
-                                                    EColumnType::kUInt64);
+                                                    ENTupleColumnType::kUInt64);
 
   // Split integer encoding
   auto SplitInt16 = MakeFundamentalField<std::int16_t>(
-      *model, "SplitInt16", EColumnType::kSplitInt16);
+      *model, "SplitInt16", ENTupleColumnType::kSplitInt16);
   auto SplitUInt16 = MakeFundamentalField<std::uint16_t>(
-      *model, "SplitUInt16", EColumnType::kSplitUInt16);
+      *model, "SplitUInt16", ENTupleColumnType::kSplitUInt16);
   auto SplitInt32 = MakeFundamentalField<std::int32_t>(
-      *model, "SplitInt32", EColumnType::kSplitInt32);
+      *model, "SplitInt32", ENTupleColumnType::kSplitInt32);
   auto SplitUInt32 = MakeFundamentalField<std::uint32_t>(
-      *model, "SplitUInt32", EColumnType::kSplitUInt32);
+      *model, "SplitUInt32", ENTupleColumnType::kSplitUInt32);
   auto SplitInt64 = MakeFundamentalField<std::int64_t>(
-      *model, "SplitInt64", EColumnType::kSplitInt64);
+      *model, "SplitInt64", ENTupleColumnType::kSplitInt64);
   auto SplitUInt64 = MakeFundamentalField<std::uint64_t>(
-      *model, "SplitUInt64", EColumnType::kSplitUInt64);
+      *model, "SplitUInt64", ENTupleColumnType::kSplitUInt64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/fundamental/integer/write.C
+++ b/types/fundamental/integer/write.C
@@ -4,67 +4,61 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <string_view>
 
 template <typename T>
-static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
+static std::shared_ptr<T> MakeFundamentalField(ROOT::RNTupleModel &model,
                                                std::string_view name,
-                                               ENTupleColumnType type) {
-  auto field = std::make_unique<RField<T>>(name);
+                                               ROOT::ENTupleColumnType type) {
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }
 
 void write(std::string_view filename = "types.fundamental.integer.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
-  auto Int8 =
-      MakeFundamentalField<std::int8_t>(*model, "Int8", ENTupleColumnType::kInt8);
-  auto UInt8 =
-      MakeFundamentalField<std::uint8_t>(*model, "UInt8", ENTupleColumnType::kUInt8);
+  auto Int8 = MakeFundamentalField<std::int8_t>(*model, "Int8",
+                                                ROOT::ENTupleColumnType::kInt8);
+  auto UInt8 = MakeFundamentalField<std::uint8_t>(
+      *model, "UInt8", ROOT::ENTupleColumnType::kUInt8);
 
   // Non-split integer encoding
-  auto Int16 =
-      MakeFundamentalField<std::int16_t>(*model, "Int16", ENTupleColumnType::kInt16);
-  auto UInt16 = MakeFundamentalField<std::uint16_t>(*model, "UInt16",
-                                                    ENTupleColumnType::kUInt16);
-  auto Int32 =
-      MakeFundamentalField<std::int32_t>(*model, "Int32", ENTupleColumnType::kInt32);
-  auto UInt32 = MakeFundamentalField<std::uint32_t>(*model, "UInt32",
-                                                    ENTupleColumnType::kUInt32);
-  auto Int64 =
-      MakeFundamentalField<std::int64_t>(*model, "Int64", ENTupleColumnType::kInt64);
-  auto UInt64 = MakeFundamentalField<std::uint64_t>(*model, "UInt64",
-                                                    ENTupleColumnType::kUInt64);
+  auto Int16 = MakeFundamentalField<std::int16_t>(
+      *model, "Int16", ROOT::ENTupleColumnType::kInt16);
+  auto UInt16 = MakeFundamentalField<std::uint16_t>(
+      *model, "UInt16", ROOT::ENTupleColumnType::kUInt16);
+  auto Int32 = MakeFundamentalField<std::int32_t>(
+      *model, "Int32", ROOT::ENTupleColumnType::kInt32);
+  auto UInt32 = MakeFundamentalField<std::uint32_t>(
+      *model, "UInt32", ROOT::ENTupleColumnType::kUInt32);
+  auto Int64 = MakeFundamentalField<std::int64_t>(
+      *model, "Int64", ROOT::ENTupleColumnType::kInt64);
+  auto UInt64 = MakeFundamentalField<std::uint64_t>(
+      *model, "UInt64", ROOT::ENTupleColumnType::kUInt64);
 
   // Split integer encoding
   auto SplitInt16 = MakeFundamentalField<std::int16_t>(
-      *model, "SplitInt16", ENTupleColumnType::kSplitInt16);
+      *model, "SplitInt16", ROOT::ENTupleColumnType::kSplitInt16);
   auto SplitUInt16 = MakeFundamentalField<std::uint16_t>(
-      *model, "SplitUInt16", ENTupleColumnType::kSplitUInt16);
+      *model, "SplitUInt16", ROOT::ENTupleColumnType::kSplitUInt16);
   auto SplitInt32 = MakeFundamentalField<std::int32_t>(
-      *model, "SplitInt32", ENTupleColumnType::kSplitInt32);
+      *model, "SplitInt32", ROOT::ENTupleColumnType::kSplitInt32);
   auto SplitUInt32 = MakeFundamentalField<std::uint32_t>(
-      *model, "SplitUInt32", ENTupleColumnType::kSplitUInt32);
+      *model, "SplitUInt32", ROOT::ENTupleColumnType::kSplitUInt32);
   auto SplitInt64 = MakeFundamentalField<std::int64_t>(
-      *model, "SplitInt64", ENTupleColumnType::kSplitInt64);
+      *model, "SplitInt64", ROOT::ENTupleColumnType::kSplitInt64);
   auto SplitUInt64 = MakeFundamentalField<std::uint64_t>(
-      *model, "SplitUInt64", ENTupleColumnType::kSplitUInt64);
+      *model, "SplitUInt64", ROOT::ENTupleColumnType::kSplitUInt64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *Int8 = 1;

--- a/types/fundamental/misc/read.C
+++ b/types/fundamental/misc/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstddef> // for std::byte
 #include <fstream>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintIntegerValue(const REntry &entry, std::string_view name,
+static void PrintIntegerValue(const ROOT::REntry &entry, std::string_view name,
                               std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": ";
@@ -29,7 +26,7 @@ void read(std::string_view input = "types.fundamental.misc.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/fundamental/misc/read.C
+++ b/types/fundamental/misc/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstddef> // for std::byte
 #include <fstream>

--- a/types/fundamental/misc/write.C
+++ b/types/fundamental/misc/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/fundamental/misc/write.C
+++ b/types/fundamental/misc/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstddef> // for std::byte
 #include <limits>
@@ -18,7 +18,7 @@ using ROOT::Experimental::RNTupleWriter;
 template <typename T>
 static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType type) {
+                                               ENTupleColumnType type) {
   auto field = std::make_unique<RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
@@ -28,10 +28,10 @@ static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
 void write(std::string_view filename = "types.fundamental.misc.root") {
   auto model = RNTupleModel::Create();
 
-  auto Bit = MakeFundamentalField<bool>(*model, "Bit", EColumnType::kBit);
+  auto Bit = MakeFundamentalField<bool>(*model, "Bit", ENTupleColumnType::kBit);
   auto Byte =
-      MakeFundamentalField<std::byte>(*model, "Byte", EColumnType::kByte);
-  auto Char = MakeFundamentalField<char>(*model, "Char", EColumnType::kChar);
+      MakeFundamentalField<std::byte>(*model, "Byte", ENTupleColumnType::kByte);
+  auto Char = MakeFundamentalField<char>(*model, "Char", ENTupleColumnType::kChar);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/fundamental/misc/write.C
+++ b/types/fundamental/misc/write.C
@@ -4,39 +4,35 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstddef> // for std::byte
 #include <limits>
 #include <memory>
 #include <string_view>
 
 template <typename T>
-static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
+static std::shared_ptr<T> MakeFundamentalField(ROOT::RNTupleModel &model,
                                                std::string_view name,
-                                               ENTupleColumnType type) {
-  auto field = std::make_unique<RField<T>>(name);
+                                               ROOT::ENTupleColumnType type) {
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }
 
 void write(std::string_view filename = "types.fundamental.misc.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
-  auto Bit = MakeFundamentalField<bool>(*model, "Bit", ENTupleColumnType::kBit);
-  auto Byte =
-      MakeFundamentalField<std::byte>(*model, "Byte", ENTupleColumnType::kByte);
-  auto Char = MakeFundamentalField<char>(*model, "Char", ENTupleColumnType::kChar);
+  auto Bit =
+      MakeFundamentalField<bool>(*model, "Bit", ROOT::ENTupleColumnType::kBit);
+  auto Byte = MakeFundamentalField<std::byte>(*model, "Byte",
+                                              ROOT::ENTupleColumnType::kByte);
+  auto Char = MakeFundamentalField<char>(*model, "Char",
+                                         ROOT::ENTupleColumnType::kChar);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *Bit = 1;

--- a/types/fundamental/real/read.C
+++ b/types/fundamental/real/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <fstream>
 #include <ios>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintRealValue(const REntry &entry, std::string_view name,
+static void PrintRealValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": \"" << value << "\"";
@@ -28,7 +25,7 @@ void read(std::string_view input = "types.fundamental.real.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/fundamental/real/read.C
+++ b/types/fundamental/real/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <fstream>
 #include <ios>

--- a/types/fundamental/real/write.C
+++ b/types/fundamental/real/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/fundamental/real/write.C
+++ b/types/fundamental/real/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <limits>
 #include <memory>
@@ -17,7 +17,7 @@ using ROOT::Experimental::RNTupleWriter;
 template <typename T>
 static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType type) {
+                                               ENTupleColumnType type) {
   auto field = std::make_unique<RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
@@ -29,24 +29,24 @@ void write(std::string_view filename = "types.fundamental.real.root") {
 
   // Non-split float encoding
   auto FloatReal16 =
-      MakeFundamentalField<float>(*model, "FloatReal16", EColumnType::kReal16);
+      MakeFundamentalField<float>(*model, "FloatReal16", ENTupleColumnType::kReal16);
   auto FloatReal32 =
-      MakeFundamentalField<float>(*model, "FloatReal32", EColumnType::kReal32);
+      MakeFundamentalField<float>(*model, "FloatReal32", ENTupleColumnType::kReal32);
   auto DoubleReal16 = MakeFundamentalField<double>(*model, "DoubleReal16",
-                                                   EColumnType::kReal16);
+                                                   ENTupleColumnType::kReal16);
   auto DoubleReal32 = MakeFundamentalField<double>(*model, "DoubleReal32",
-                                                   EColumnType::kReal32);
+                                                   ENTupleColumnType::kReal32);
   auto DoubleReal64 = MakeFundamentalField<double>(*model, "DoubleReal64",
-                                                   EColumnType::kReal64);
+                                                   ENTupleColumnType::kReal64);
 
   // Split float encoding
   // NB there is no kSplitReal16
   auto FloatSplitReal32 = MakeFundamentalField<float>(
-      *model, "FloatSplitReal32", EColumnType::kSplitReal32);
+      *model, "FloatSplitReal32", ENTupleColumnType::kSplitReal32);
   auto DoubleSplitReal32 = MakeFundamentalField<double>(
-      *model, "DoubleSplitReal32", EColumnType::kSplitReal32);
+      *model, "DoubleSplitReal32", ENTupleColumnType::kSplitReal32);
   auto DoubleSplitReal64 = MakeFundamentalField<double>(
-      *model, "DoubleSplitReal64", EColumnType::kSplitReal64);
+      *model, "DoubleSplitReal64", ENTupleColumnType::kSplitReal64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/fundamental/real/write.C
+++ b/types/fundamental/real/write.C
@@ -4,54 +4,48 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <limits>
 #include <memory>
 #include <string_view>
 
 template <typename T>
-static std::shared_ptr<T> MakeFundamentalField(RNTupleModel &model,
+static std::shared_ptr<T> MakeFundamentalField(ROOT::RNTupleModel &model,
                                                std::string_view name,
-                                               ENTupleColumnType type) {
-  auto field = std::make_unique<RField<T>>(name);
+                                               ROOT::ENTupleColumnType type) {
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   field->SetColumnRepresentatives({{type}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }
 
 void write(std::string_view filename = "types.fundamental.real.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split float encoding
-  auto FloatReal16 =
-      MakeFundamentalField<float>(*model, "FloatReal16", ENTupleColumnType::kReal16);
-  auto FloatReal32 =
-      MakeFundamentalField<float>(*model, "FloatReal32", ENTupleColumnType::kReal32);
-  auto DoubleReal16 = MakeFundamentalField<double>(*model, "DoubleReal16",
-                                                   ENTupleColumnType::kReal16);
-  auto DoubleReal32 = MakeFundamentalField<double>(*model, "DoubleReal32",
-                                                   ENTupleColumnType::kReal32);
-  auto DoubleReal64 = MakeFundamentalField<double>(*model, "DoubleReal64",
-                                                   ENTupleColumnType::kReal64);
+  auto FloatReal16 = MakeFundamentalField<float>(
+      *model, "FloatReal16", ROOT::ENTupleColumnType::kReal16);
+  auto FloatReal32 = MakeFundamentalField<float>(
+      *model, "FloatReal32", ROOT::ENTupleColumnType::kReal32);
+  auto DoubleReal16 = MakeFundamentalField<double>(
+      *model, "DoubleReal16", ROOT::ENTupleColumnType::kReal16);
+  auto DoubleReal32 = MakeFundamentalField<double>(
+      *model, "DoubleReal32", ROOT::ENTupleColumnType::kReal32);
+  auto DoubleReal64 = MakeFundamentalField<double>(
+      *model, "DoubleReal64", ROOT::ENTupleColumnType::kReal64);
 
   // Split float encoding
   // NB there is no kSplitReal16
   auto FloatSplitReal32 = MakeFundamentalField<float>(
-      *model, "FloatSplitReal32", ENTupleColumnType::kSplitReal32);
+      *model, "FloatSplitReal32", ROOT::ENTupleColumnType::kSplitReal32);
   auto DoubleSplitReal32 = MakeFundamentalField<double>(
-      *model, "DoubleSplitReal32", ENTupleColumnType::kSplitReal32);
+      *model, "DoubleSplitReal32", ROOT::ENTupleColumnType::kSplitReal32);
   auto DoubleSplitReal64 = MakeFundamentalField<double>(
-      *model, "DoubleSplitReal64", ENTupleColumnType::kSplitReal64);
+      *model, "DoubleSplitReal64", ROOT::ENTupleColumnType::kSplitReal64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *FloatReal16 = 1.0f;

--- a/types/fundamental/real32quant/read.C
+++ b/types/fundamental/real32quant/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <fstream>
 #include <ios>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintRealValue(const REntry &entry, std::string_view name,
+static void PrintRealValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": \"" << value << "\"";
@@ -28,7 +25,7 @@ void read(std::string_view input = "types.fundamental.real32quant.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/fundamental/real32quant/read.C
+++ b/types/fundamental/real32quant/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <fstream>
 #include <ios>

--- a/types/fundamental/real32quant/write.C
+++ b/types/fundamental/real32quant/write.C
@@ -4,11 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <limits>
 #include <memory>
 #include <string_view>
@@ -16,19 +11,19 @@ using ROOT::RNTupleWriter;
 static constexpr double pi = 3.14159265358979323846;
 
 template <typename T>
-static std::shared_ptr<T> MakeFieldReal32Quant(RNTupleModel &model,
-                                               std::string_view name,
-                                               int nBits, double min, double max) {
+static std::shared_ptr<T> MakeFieldReal32Quant(ROOT::RNTupleModel &model,
+                                               std::string_view name, int nBits,
+                                               double min, double max) {
   assert(nBits >= 1 && nBits <= 32);
   assert(max > min);
-  auto field = std::make_unique<RField<T>>(name);
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   field->SetQuantized(min, max, nBits);
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }
 
 void write(std::string_view filename = "types.fundamental.real32quant.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto FloatReal32Quant1 =
       MakeFieldReal32Quant<float>(*model, "FloatReal32Quant1", 1, -1, 1);
@@ -43,9 +38,10 @@ void write(std::string_view filename = "types.fundamental.real32quant.root") {
   auto DoubleReal32Quant32 =
       MakeFieldReal32Quant<double>(*model, "DoubleReal32Quant32", 32, -100, 25);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *FloatReal32Quant1 = -1.0f;

--- a/types/fundamental/real32quant/write.C
+++ b/types/fundamental/real32quant/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/fundamental/real32quant/write.C
+++ b/types/fundamental/real32quant/write.C
@@ -4,11 +4,10 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <limits>
 #include <memory>

--- a/types/fundamental/real32quant/write.C
+++ b/types/fundamental/real32quant/write.C
@@ -7,6 +7,7 @@
 #endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RVersion.hxx>
 
 #include <limits>
 #include <memory>
@@ -21,7 +22,11 @@ static std::shared_ptr<T> MakeFieldReal32Quant(ROOT::RNTupleModel &model,
   assert(nBits >= 1 && nBits <= 32);
   assert(max > min);
   auto field = std::make_unique<ROOT::RField<T>>(name);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  field->SetQuantized(nBits, {min, max});
+#else
   field->SetQuantized(min, max, nBits);
+#endif
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }

--- a/types/fundamental/real32trunc/read.C
+++ b/types/fundamental/real32trunc/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <fstream>
 #include <ios>
 #include <ostream>
@@ -11,7 +8,7 @@ using ROOT::RNTupleReader;
 #include <string_view>
 
 template <typename T>
-static void PrintRealValue(const REntry &entry, std::string_view name,
+static void PrintRealValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": \"" << value << "\"";
@@ -28,7 +25,7 @@ void read(std::string_view input = "types.fundamental.real32trunc.root",
   os << std::hexfloat;
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/fundamental/real32trunc/read.C
+++ b/types/fundamental/real32trunc/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <fstream>
 #include <ios>

--- a/types/fundamental/real32trunc/write.C
+++ b/types/fundamental/real32trunc/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/fundamental/real32trunc/write.C
+++ b/types/fundamental/real32trunc/write.C
@@ -4,29 +4,23 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <limits>
 #include <memory>
 #include <string_view>
 
 template <typename T>
-static std::shared_ptr<T> MakeFieldReal32Trunc(RNTupleModel &model,
+static std::shared_ptr<T> MakeFieldReal32Trunc(ROOT::RNTupleModel &model,
                                                std::string_view name,
                                                int nBits) {
   assert(nBits >= 10 && nBits < 32);
-  auto field = std::make_unique<RField<T>>(name);
+  auto field = std::make_unique<ROOT::RField<T>>(name);
   field->SetTruncated(nBits);
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<T>(name);
 }
 
 void write(std::string_view filename = "types.fundamental.real32trunc.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto FloatReal32Trunc10 =
       MakeFieldReal32Trunc<float>(*model, "FloatReal32Trunc10", 10);
@@ -41,10 +35,10 @@ void write(std::string_view filename = "types.fundamental.real32trunc.root") {
   auto DoubleReal32Trunc31 =
       MakeFieldReal32Trunc<double>(*model, "DoubleReal32Trunc31", 31);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: ascending values
   *FloatReal32Trunc10 = 1.0f;

--- a/types/fundamental/real32trunc/write.C
+++ b/types/fundamental/real32trunc/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <limits>
 #include <memory>

--- a/types/map/fundamental/read.C
+++ b/types/map/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/map/fundamental/read.C
+++ b/types/map/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using Map = std::map<std::string, std::int32_t>;
 
-static void PrintMapValue(const REntry &entry, std::string_view name,
+static void PrintMapValue(const ROOT::REntry &entry, std::string_view name,
                           std::ostream &os, bool last = false) {
   Map &item = *entry.GetPtr<Map>(name);
   os << "    \"" << name << "\": {";
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.map.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/map/fundamental/write.C
+++ b/types/map/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <map>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using Map = std::map<std::string, std::int32_t>;
 
-static std::shared_ptr<Map> MakeMapField(RNTupleModel &model,
+static std::shared_ptr<Map> MakeMapField(ROOT::RNTupleModel &model,
                                          std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Map>>(name);
+                                         ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Map>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Map>(name);
 }
 
 void write(std::string_view filename = "types.map.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMapField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMapField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", 1}};

--- a/types/map/fundamental/write.C
+++ b/types/map/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using Map = std::map<std::string, std::int32_t>;
 
 static std::shared_ptr<Map> MakeMapField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Map>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.map.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/map/fundamental/write.C
+++ b/types/map/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/map/nested/read.C
+++ b/types/map/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/map/nested/read.C
+++ b/types/map/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -16,8 +13,9 @@ using ROOT::RNTupleReader;
 
 using Map = std::map<std::string, std::map<std::string, std::int32_t>>;
 
-static void PrintNestedMapValue(const REntry &entry, std::string_view name,
-                                std::ostream &os, bool last = false) {
+static void PrintNestedMapValue(const ROOT::REntry &entry,
+                                std::string_view name, std::ostream &os,
+                                bool last = false) {
   Map &item = *entry.GetPtr<Map>(name);
   os << "    \"" << name << "\": {";
   bool outerFirst = true;
@@ -61,7 +59,7 @@ void read(std::string_view input = "types.map.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/map/nested/write.C
+++ b/types/map/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -22,11 +22,12 @@ using Map = std::map<std::string, std::map<std::string, std::int32_t>>;
 
 static std::shared_ptr<Map> MakeMapField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Map>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->GetSubFields()[1]->SetColumnRepresentatives(
-      {{indexType}});
+  field->GetMutableSubfields()[0]
+      ->GetMutableSubfields()[1]
+      ->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Map>(name);
 }
@@ -39,14 +40,14 @@ void write(std::string_view filename = "types.map.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/map/nested/write.C
+++ b/types/map/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/map/nested/write.C
+++ b/types/map/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -20,10 +14,10 @@ using ROOT::RNTupleWriter;
 
 using Map = std::map<std::string, std::map<std::string, std::int32_t>>;
 
-static std::shared_ptr<Map> MakeMapField(RNTupleModel &model,
+static std::shared_ptr<Map> MakeMapField(ROOT::RNTupleModel &model,
                                          std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Map>>(name);
+                                         ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Map>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]
       ->GetMutableSubfields()[1]
@@ -37,22 +31,24 @@ void write(std::string_view filename = "types.map.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMapField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMapField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", {{"aa", 1}}}};

--- a/types/multimap/fundamental/read.C
+++ b/types/multimap/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/multimap/fundamental/read.C
+++ b/types/multimap/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,8 +10,8 @@ using ROOT::RNTupleReader;
 
 using Multimap = std::multimap<std::string, std::int32_t>;
 
-static void PrintMultimapValue(const REntry &entry, std::string_view name,
-                          std::ostream &os, bool last = false) {
+static void PrintMultimapValue(const ROOT::REntry &entry, std::string_view name,
+                               std::ostream &os, bool last = false) {
   Multimap &item = *entry.GetPtr<Multimap>(name);
   os << "    \"" << name << "\": {";
   bool first = true;
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.multimap.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/multimap/fundamental/write.C
+++ b/types/multimap/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/multimap/fundamental/write.C
+++ b/types/multimap/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using Multimap = std::multimap<std::string, std::int32_t>;
 
-static std::shared_ptr<Multimap> MakeMultimapField(RNTupleModel &model,
-                                                   std::string_view name,
-                                                   ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Multimap>>(name);
+static std::shared_ptr<Multimap>
+MakeMultimapField(ROOT::RNTupleModel &model, std::string_view name,
+                  ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Multimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Multimap>(name);
 }
 
 void write(std::string_view filename = "types.multimap.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMultimapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMultimapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMultimapField(*model, "SplitIndex32",
+                                        ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMultimapField(*model, "SplitIndex64",
+                                        ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", 1}};

--- a/types/multimap/fundamental/write.C
+++ b/types/multimap/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <map>
@@ -19,7 +19,7 @@ using Multimap = std::multimap<std::string, std::int32_t>;
 
 static std::shared_ptr<Multimap> MakeMultimapField(RNTupleModel &model,
                                                    std::string_view name,
-                                                   EColumnType indexType) {
+                                                   ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Multimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.multimap.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/multimap/nested/read.C
+++ b/types/multimap/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/multimap/nested/read.C
+++ b/types/multimap/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -17,8 +14,9 @@ using ROOT::RNTupleReader;
 using Multimap =
     std::multimap<std::string, std::multimap<std::string, std::int32_t>>;
 
-static void PrintNestedMultimapValue(const REntry &entry, std::string_view name,
-                                     std::ostream &os, bool last = false) {
+static void PrintNestedMultimapValue(const ROOT::REntry &entry,
+                                     std::string_view name, std::ostream &os,
+                                     bool last = false) {
   Multimap &item = *entry.GetPtr<Multimap>(name);
   os << "    \"" << name << "\": {";
   bool outerFirst = true;
@@ -62,7 +60,7 @@ void read(std::string_view input = "types.multimap.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/multimap/nested/write.C
+++ b/types/multimap/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -23,11 +23,12 @@ using Multimap =
 
 static std::shared_ptr<Multimap> MakeMultimapField(RNTupleModel &model,
                                                    std::string_view name,
-                                                   EColumnType indexType) {
+                                                   ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Multimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->GetSubFields()[1]->SetColumnRepresentatives(
-      {{indexType}});
+  field->GetMutableSubfields()[0]
+      ->GetMutableSubfields()[1]
+      ->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Multimap>(name);
 }
@@ -40,14 +41,14 @@ void write(std::string_view filename = "types.multimap.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/multimap/nested/write.C
+++ b/types/multimap/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/multimap/nested/write.C
+++ b/types/multimap/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -21,10 +15,10 @@ using ROOT::RNTupleWriter;
 using Multimap =
     std::multimap<std::string, std::multimap<std::string, std::int32_t>>;
 
-static std::shared_ptr<Multimap> MakeMultimapField(RNTupleModel &model,
-                                                   std::string_view name,
-                                                   ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Multimap>>(name);
+static std::shared_ptr<Multimap>
+MakeMultimapField(ROOT::RNTupleModel &model, std::string_view name,
+                  ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Multimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]
       ->GetMutableSubfields()[1]
@@ -38,22 +32,24 @@ void write(std::string_view filename = "types.multimap.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMultimapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMultimapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMultimapField(*model, "SplitIndex32",
+                                        ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMultimapField(*model, "SplitIndex64",
+                                        ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", {{"aa", 1}}}};

--- a/types/multiset/fundamental/read.C
+++ b/types/multiset/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using Multiset = std::multiset<std::int32_t>;
 
-static void PrintMultisetValue(const REntry &entry, std::string_view name,
+static void PrintMultisetValue(const ROOT::REntry &entry, std::string_view name,
                                std::ostream &os, bool last = false) {
   Multiset &value = *entry.GetPtr<Multiset>(name);
   os << "    \"" << name << "\": [";
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.multiset.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/multiset/fundamental/read.C
+++ b/types/multiset/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/multiset/fundamental/write.C
+++ b/types/multiset/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/multiset/fundamental/write.C
+++ b/types/multiset/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <set>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using Multiset = std::multiset<std::int32_t>;
 
-static std::shared_ptr<Multiset> MakeMultisetField(RNTupleModel &model,
-                                                   std::string_view name,
-                                                   ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Multiset>>(name);
+static std::shared_ptr<Multiset>
+MakeMultisetField(ROOT::RNTupleModel &model, std::string_view name,
+                  ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Multiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Multiset>(name);
 }
 
 void write(std::string_view filename = "types.multiset.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMultisetField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMultisetField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMultisetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMultisetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMultisetField(*model, "SplitIndex32",
+                                        ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMultisetField(*model, "SplitIndex64",
+                                        ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {1};

--- a/types/multiset/fundamental/write.C
+++ b/types/multiset/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using Multiset = std::multiset<std::int32_t>;
 
 static std::shared_ptr<Multiset> MakeMultisetField(RNTupleModel &model,
                                                    std::string_view name,
-                                                   EColumnType indexType) {
+                                                   ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Multiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.multiset.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultisetField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMultisetField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMultisetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMultisetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMultisetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMultisetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/multiset/nested/read.C
+++ b/types/multiset/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/multiset/nested/read.C
+++ b/types/multiset/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -16,8 +13,9 @@ using ROOT::RNTupleReader;
 
 using Multiset = std::multiset<std::multiset<std::int32_t>>;
 
-static void PrintNestedMultisetValue(const REntry &entry, std::string_view name,
-                                     std::ostream &os, bool last = false) {
+static void PrintNestedMultisetValue(const ROOT::REntry &entry,
+                                     std::string_view name, std::ostream &os,
+                                     bool last = false) {
   Multiset &value = *entry.GetPtr<Multiset>(name);
   os << "    \"" << name << "\": [";
   bool outerFirst = true;
@@ -61,7 +59,7 @@ void read(std::string_view input = "types.multiset.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/multiset/nested/write.C
+++ b/types/multiset/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -20,10 +14,10 @@ using ROOT::RNTupleWriter;
 
 using Multiset = std::multiset<std::multiset<std::int32_t>>;
 
-static std::shared_ptr<Multiset> MakeMultisetField(RNTupleModel &model,
-                                                   std::string_view name,
-                                                   ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Multiset>>(name);
+static std::shared_ptr<Multiset>
+MakeMultisetField(ROOT::RNTupleModel &model, std::string_view name,
+                  ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Multiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -35,22 +29,24 @@ void write(std::string_view filename = "types.multiset.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMultisetField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMultisetField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMultisetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMultisetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMultisetField(*model, "SplitIndex32",
+                                        ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMultisetField(*model, "SplitIndex64",
+                                        ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {{1}};

--- a/types/multiset/nested/write.C
+++ b/types/multiset/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/multiset/nested/write.C
+++ b/types/multiset/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -22,10 +22,10 @@ using Multiset = std::multiset<std::multiset<std::int32_t>>;
 
 static std::shared_ptr<Multiset> MakeMultisetField(RNTupleModel &model,
                                                    std::string_view name,
-                                                   EColumnType indexType) {
+                                                   ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Multiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Multiset>(name);
 }
@@ -38,14 +38,14 @@ void write(std::string_view filename = "types.multiset.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultisetField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMultisetField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMultisetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMultisetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMultisetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMultisetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/optional/read.C
+++ b/types/optional/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <optional>
@@ -52,7 +49,7 @@ template <> void PrintValue(const VectorInt32Ty &value, std::ostream &os) {
 }
 
 template <typename T>
-static void PrintOptionalValue(const REntry &entry, std::string_view name,
+static void PrintOptionalValue(const ROOT::REntry &entry, std::string_view name,
                                std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::optional<T>>(name);
   os << "    \"" << name << "\": ";
@@ -67,8 +64,9 @@ static void PrintOptionalValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVectorOptValue(const REntry &entry, std::string_view name,
-                                std::ostream &os, bool last = false) {
+static void PrintVectorOptValue(const ROOT::REntry &entry,
+                                std::string_view name, std::ostream &os,
+                                bool last = false) {
   auto &value = *entry.GetPtr<std::vector<std::optional<std::int32_t>>>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -100,7 +98,7 @@ void read(std::string_view input = "types.optional.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/optional/read.C
+++ b/types/optional/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/optional/write.C
+++ b/types/optional/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -24,7 +24,7 @@ using VectorInt32Ty = std::vector<std::int32_t>;
 
 static std::shared_ptr<OptInt32Ty> MakeIntField(RNTupleModel &model,
                                                 std::string_view name,
-                                                EColumnType indexType) {
+                                                ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<OptInt32Ty>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -35,14 +35,14 @@ void write(std::string_view filename = "types.optional.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeIntField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeIntField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeIntField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeIntField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeIntField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeIntField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeIntField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeIntField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   auto String = model->MakeField<std::optional<std::string>>("String");
   auto Variant = model->MakeField<std::optional<VariantTy>>("Variant");

--- a/types/optional/write.C
+++ b/types/optional/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/optional/write.C
+++ b/types/optional/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -22,27 +16,29 @@ using OptInt32Ty = std::optional<std::int32_t>;
 using VariantTy = std::variant<std::int32_t, std::string>;
 using VectorInt32Ty = std::vector<std::int32_t>;
 
-static std::shared_ptr<OptInt32Ty> MakeIntField(RNTupleModel &model,
-                                                std::string_view name,
-                                                ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<OptInt32Ty>>(name);
+static std::shared_ptr<OptInt32Ty>
+MakeIntField(ROOT::RNTupleModel &model, std::string_view name,
+             ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<OptInt32Ty>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<OptInt32Ty>(name);
 }
 
 void write(std::string_view filename = "types.optional.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeIntField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeIntField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeIntField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeIntField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeIntField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeIntField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeIntField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeIntField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
   auto String = model->MakeField<std::optional<std::string>>("String");
   auto Variant = model->MakeField<std::optional<VariantTy>>("Variant");
@@ -51,10 +47,10 @@ void write(std::string_view filename = "types.optional.root") {
   auto VectorOpt =
       model->MakeField<std::vector<std::optional<std::int32_t>>>("VectorOpt");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *Index32 = 1;

--- a/types/pair/read.C
+++ b/types/pair/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -60,7 +57,7 @@ template <> void PrintValue(const Pair_Int32_String &value, std::ostream &os) {
 }
 
 template <typename T, typename U>
-static void PrintPairValue(const REntry &entry, std::string_view name,
+static void PrintPairValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::pair<T, U>>(name);
   os << "    \"" << name << "\": [\n";
@@ -77,8 +74,9 @@ static void PrintPairValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVectorPairValue(const REntry &entry, std::string_view name,
-                                 std::ostream &os, bool last = false) {
+static void PrintVectorPairValue(const ROOT::REntry &entry,
+                                 std::string_view name, std::ostream &os,
+                                 bool last = false) {
   auto &value = *entry.GetPtr<std::vector<Pair_Int32_String>>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -106,7 +104,7 @@ void read(std::string_view input = "types.pair.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/pair/read.C
+++ b/types/pair/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/pair/write.C
+++ b/types/pair/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>

--- a/types/pair/write.C
+++ b/types/pair/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -19,7 +15,7 @@ using Variant = std::variant<std::int32_t, std::string>;
 using VectorInt32 = std::vector<std::int32_t>;
 
 void write(std::string_view filename = "types.pair.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int32_String = model->MakeField<Pair_Int32_String>("Int32_String");
   auto Variant_Vector =
@@ -29,10 +25,10 @@ void write(std::string_view filename = "types.pair.root") {
   auto VectorPair =
       model->MakeField<std::vector<Pair_Int32_String>>("VectorPair");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *Int32_String = {1, "abc"};

--- a/types/set/fundamental/read.C
+++ b/types/set/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using Set = std::set<std::int32_t>;
 
-static void PrintSetValue(const REntry &entry, std::string_view name,
+static void PrintSetValue(const ROOT::REntry &entry, std::string_view name,
                           std::ostream &os, bool last = false) {
   Set &value = *entry.GetPtr<Set>(name);
   os << "    \"" << name << "\": [";
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.set.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/set/fundamental/read.C
+++ b/types/set/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/set/fundamental/write.C
+++ b/types/set/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/set/fundamental/write.C
+++ b/types/set/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using Set = std::set<std::int32_t>;
 
 static std::shared_ptr<Set> MakeSetField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Set>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.set.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeSetField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeSetField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeSetField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeSetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeSetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeSetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/set/fundamental/write.C
+++ b/types/set/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <set>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using Set = std::set<std::int32_t>;
 
-static std::shared_ptr<Set> MakeSetField(RNTupleModel &model,
+static std::shared_ptr<Set> MakeSetField(ROOT::RNTupleModel &model,
                                          std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Set>>(name);
+                                         ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Set>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Set>(name);
 }
 
 void write(std::string_view filename = "types.set.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeSetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeSetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeSetField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeSetField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeSetField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeSetField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {1};

--- a/types/set/nested/read.C
+++ b/types/set/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -16,8 +13,9 @@ using ROOT::RNTupleReader;
 
 using Set = std::set<std::set<std::int32_t>>;
 
-static void PrintNestedSetValue(const REntry &entry, std::string_view name,
-                                std::ostream &os, bool last = false) {
+static void PrintNestedSetValue(const ROOT::REntry &entry,
+                                std::string_view name, std::ostream &os,
+                                bool last = false) {
   Set &value = *entry.GetPtr<Set>(name);
   os << "    \"" << name << "\": [";
   bool outerFirst = true;
@@ -61,7 +59,7 @@ void read(std::string_view input = "types.set.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/set/nested/read.C
+++ b/types/set/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/set/nested/write.C
+++ b/types/set/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -20,10 +14,10 @@ using ROOT::RNTupleWriter;
 
 using Set = std::set<std::set<std::int32_t>>;
 
-static std::shared_ptr<Set> MakeSetField(RNTupleModel &model,
+static std::shared_ptr<Set> MakeSetField(ROOT::RNTupleModel &model,
                                          std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Set>>(name);
+                                         ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Set>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -35,22 +29,24 @@ void write(std::string_view filename = "types.set.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeSetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeSetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeSetField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeSetField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeSetField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeSetField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {{1}};

--- a/types/set/nested/write.C
+++ b/types/set/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/set/nested/write.C
+++ b/types/set/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -22,10 +22,10 @@ using Set = std::set<std::set<std::int32_t>>;
 
 static std::shared_ptr<Set> MakeSetField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Set>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Set>(name);
 }
@@ -38,14 +38,14 @@ void write(std::string_view filename = "types.set.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeSetField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeSetField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeSetField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeSetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeSetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeSetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/string/read.C
+++ b/types/string/read.C
@@ -1,15 +1,12 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <fstream>
 #include <ostream>
 #include <string>
 #include <string_view>
 
-static void PrintStringValue(const REntry &entry, std::string_view name,
+static void PrintStringValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   std::string &value = *entry.GetPtr<std::string>(name);
   os << "    \"" << name << "\": \"" << value << "\"";
@@ -24,7 +21,7 @@ void read(std::string_view input = "types.string.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/string/read.C
+++ b/types/string/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <fstream>
 #include <ostream>

--- a/types/string/write.C
+++ b/types/string/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/string/write.C
+++ b/types/string/write.C
@@ -4,42 +4,39 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <memory>
 #include <string>
 #include <string_view>
 
-static std::shared_ptr<std::string> MakeStringField(RNTupleModel &model,
-                                                    std::string_view name,
-                                                    ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<std::string>>(name);
-  field->SetColumnRepresentatives({{indexType, ENTupleColumnType::kChar}});
+static std::shared_ptr<std::string>
+MakeStringField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<std::string>>(name);
+  field->SetColumnRepresentatives(
+      {{indexType, ROOT::ENTupleColumnType::kChar}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<std::string>(name);
 }
 
 void write(std::string_view filename = "types.string.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeStringField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeStringField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeStringField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeStringField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeStringField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeStringField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeStringField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeStringField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: one character strings, with ascending values
   *Index32 = "a";

--- a/types/string/write.C
+++ b/types/string/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <memory>
 #include <string>
@@ -16,9 +16,9 @@ using ROOT::Experimental::RNTupleWriter;
 
 static std::shared_ptr<std::string> MakeStringField(RNTupleModel &model,
                                                     std::string_view name,
-                                                    EColumnType indexType) {
+                                                    ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<std::string>>(name);
-  field->SetColumnRepresentatives({{indexType, EColumnType::kChar}});
+  field->SetColumnRepresentatives({{indexType, ENTupleColumnType::kChar}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<std::string>(name);
 }
@@ -27,14 +27,14 @@ void write(std::string_view filename = "types.string.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeStringField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeStringField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeStringField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeStringField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeStringField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeStringField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeStringField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeStringField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/tuple/read.C
+++ b/types/tuple/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/tuple/read.C
+++ b/types/tuple/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -50,7 +47,7 @@ template <> void PrintValue(const Tuple_Int32_String &value, std::ostream &os) {
   os << "      ]";
 }
 
-static void PrintTupleValue(const REntry &entry, std::string_view name,
+static void PrintTupleValue(const ROOT::REntry &entry, std::string_view name,
                             std::ostream &os, bool last = false) {
   auto &value =
       *entry.GetPtr<std::tuple<std::int32_t, std::string, VectorInt32>>(name);
@@ -71,7 +68,7 @@ static void PrintTupleValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVariantValue(const REntry &entry, std::string_view name,
+static void PrintVariantValue(const ROOT::REntry &entry, std::string_view name,
                               std::ostream &os, bool last = false) {
   auto &value =
       *entry.GetPtr<std::tuple<std::variant<std::int32_t, std::string>>>(name);
@@ -91,7 +88,7 @@ static void PrintVariantValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintNestedValue(const REntry &entry, std::string_view name,
+static void PrintNestedValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<std::tuple<Tuple_Int32_String>>(name);
   os << "    \"" << name << "\": [\n";
@@ -105,8 +102,9 @@ static void PrintNestedValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVectorTupleValue(const REntry &entry, std::string_view name,
-                                  std::ostream &os, bool last = false) {
+static void PrintVectorTupleValue(const ROOT::REntry &entry,
+                                  std::string_view name, std::ostream &os,
+                                  bool last = false) {
   auto &value = *entry.GetPtr<std::vector<Tuple_Int32_String>>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -134,7 +132,7 @@ void read(std::string_view input = "types.tuple.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/tuple/write.C
+++ b/types/tuple/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -18,7 +14,7 @@ using Tuple_Int32_String = std::tuple<std::int32_t, std::string>;
 using VectorInt32 = std::vector<std::int32_t>;
 
 void write(std::string_view filename = "types.tuple.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto Int32_String_Vector =
       model->MakeField<std::tuple<std::int32_t, std::string, VectorInt32>>(
@@ -30,10 +26,10 @@ void write(std::string_view filename = "types.tuple.root") {
   auto VectorTuple =
       model->MakeField<std::vector<Tuple_Int32_String>>("VectorTuple");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *Int32_String_Vector = {1, "abc", {2, 3, 4}};

--- a/types/tuple/write.C
+++ b/types/tuple/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>

--- a/types/unique_ptr/read.C
+++ b/types/unique_ptr/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/unique_ptr/read.C
+++ b/types/unique_ptr/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -51,8 +48,9 @@ template <> void PrintValue(const VectorInt32Ty &value, std::ostream &os) {
 }
 
 template <typename T>
-static void PrintUniquePtrValue(const REntry &entry, std::string_view name,
-                                std::ostream &os, bool last = false) {
+static void PrintUniquePtrValue(const ROOT::REntry &entry,
+                                std::string_view name, std::ostream &os,
+                                bool last = false) {
   auto &value = *entry.GetPtr<std::unique_ptr<T>>(name);
   os << "    \"" << name << "\": ";
   if (!value) {
@@ -66,8 +64,9 @@ static void PrintUniquePtrValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVectorPtrValue(const REntry &entry, std::string_view name,
-                                std::ostream &os, bool last = false) {
+static void PrintVectorPtrValue(const ROOT::REntry &entry,
+                                std::string_view name, std::ostream &os,
+                                bool last = false) {
   auto &value = *entry.GetPtr<std::vector<std::unique_ptr<std::int32_t>>>(name);
   os << "    \"" << name << "\": [";
   bool first = true;
@@ -99,7 +98,7 @@ void read(std::string_view input = "types.unique_ptr.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unique_ptr/write.C
+++ b/types/unique_ptr/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unique_ptr/write.C
+++ b/types/unique_ptr/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -21,27 +15,29 @@ using PtrInt32Ty = std::unique_ptr<std::int32_t>;
 using VariantTy = std::variant<std::int32_t, std::string>;
 using VectorInt32Ty = std::vector<std::int32_t>;
 
-static std::shared_ptr<PtrInt32Ty> MakeIntField(RNTupleModel &model,
-                                                std::string_view name,
-                                                ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<PtrInt32Ty>>(name);
+static std::shared_ptr<PtrInt32Ty>
+MakeIntField(ROOT::RNTupleModel &model, std::string_view name,
+             ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<PtrInt32Ty>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<PtrInt32Ty>(name);
 }
 
 void write(std::string_view filename = "types.unique_ptr.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeIntField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeIntField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeIntField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeIntField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeIntField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeIntField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeIntField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeIntField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
   auto String = model->MakeField<std::unique_ptr<std::string>>("String");
   auto Variant = model->MakeField<std::unique_ptr<VariantTy>>("Variant");
@@ -50,10 +46,10 @@ void write(std::string_view filename = "types.unique_ptr.root") {
   auto VectorPtr =
       model->MakeField<std::vector<std::unique_ptr<std::int32_t>>>("VectorPtr");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *Index32 = std::make_unique<std::int32_t>(1);

--- a/types/unique_ptr/write.C
+++ b/types/unique_ptr/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -23,7 +23,7 @@ using VectorInt32Ty = std::vector<std::int32_t>;
 
 static std::shared_ptr<PtrInt32Ty> MakeIntField(RNTupleModel &model,
                                                 std::string_view name,
-                                                EColumnType indexType) {
+                                                ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<PtrInt32Ty>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -34,14 +34,14 @@ void write(std::string_view filename = "types.unique_ptr.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeIntField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeIntField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeIntField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeIntField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeIntField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeIntField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeIntField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeIntField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   auto String = model->MakeField<std::unique_ptr<std::string>>("String");
   auto Variant = model->MakeField<std::unique_ptr<VariantTy>>("Variant");

--- a/types/unordered_map/fundamental/read.C
+++ b/types/unordered_map/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using UnorderedMap = std::unordered_map<std::string, std::int32_t>;
 
-static void PrintMapValue(const REntry &entry, std::string_view name,
+static void PrintMapValue(const ROOT::REntry &entry, std::string_view name,
                           std::ostream &os, bool last = false) {
   UnorderedMap &item = *entry.GetPtr<UnorderedMap>(name);
 
@@ -45,7 +42,7 @@ void read(std::string_view input = "types.unordered_map.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_map/fundamental/read.C
+++ b/types/unordered_map/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/unordered_map/fundamental/write.C
+++ b/types/unordered_map/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using UnorderedMap = std::unordered_map<std::string, std::int32_t>;
 
-static std::shared_ptr<UnorderedMap> MakeMapField(RNTupleModel &model,
-                                                  std::string_view name,
-                                                  ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMap>>(name);
+static std::shared_ptr<UnorderedMap>
+MakeMapField(ROOT::RNTupleModel &model, std::string_view name,
+             ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMap>(name);
 }
 
 void write(std::string_view filename = "types.unordered_map.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMapField(*model, "SplitIndex32",
+                                   ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMapField(*model, "SplitIndex64",
+                                   ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", 1}};

--- a/types/unordered_map/fundamental/write.C
+++ b/types/unordered_map/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using UnorderedMap = std::unordered_map<std::string, std::int32_t>;
 
 static std::shared_ptr<UnorderedMap> MakeMapField(RNTupleModel &model,
                                                   std::string_view name,
-                                                  EColumnType indexType) {
+                                                  ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.unordered_map.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_map/fundamental/write.C
+++ b/types/unordered_map/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_map/nested/read.C
+++ b/types/unordered_map/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/unordered_map/nested/read.C
+++ b/types/unordered_map/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -18,7 +15,7 @@ using UnorderedMap =
     std::unordered_map<std::string,
                        std::unordered_map<std::string, std::int32_t>>;
 
-static void PrintNestedUnorderedMapValue(const REntry &entry,
+static void PrintNestedUnorderedMapValue(const ROOT::REntry &entry,
                                          std::string_view name,
                                          std::ostream &os, bool last = false) {
   UnorderedMap &item = *entry.GetPtr<UnorderedMap>(name);
@@ -79,7 +76,7 @@ void read(std::string_view input = "types.unordered_map.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_map/nested/write.C
+++ b/types/unordered_map/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -23,11 +23,12 @@ using UnorderedMap = std::unordered_map<std::string,
 
 static std::shared_ptr<UnorderedMap> MakeUnorderedMapField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMap>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->GetSubFields()[1]->SetColumnRepresentatives(
-      {{indexType}});
+  field->GetMutableSubfields()[0]
+      ->GetMutableSubfields()[1]
+      ->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMap>(name);
 }
@@ -40,14 +41,14 @@ void write(std::string_view filename = "types.unordered_map.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeUnorderedMapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeUnorderedMapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeUnorderedMapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeUnorderedMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeUnorderedMapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeUnorderedMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_map/nested/write.C
+++ b/types/unordered_map/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_map/nested/write.C
+++ b/types/unordered_map/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -21,10 +15,10 @@ using ROOT::RNTupleWriter;
 using UnorderedMap = std::unordered_map<std::string,
                                std::unordered_map<std::string, std::int32_t>>;
 
-static std::shared_ptr<UnorderedMap> MakeUnorderedMapField(RNTupleModel &model,
-                                         std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMap>>(name);
+static std::shared_ptr<UnorderedMap>
+MakeUnorderedMapField(ROOT::RNTupleModel &model, std::string_view name,
+                      ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]
       ->GetMutableSubfields()[1]
@@ -38,22 +32,24 @@ void write(std::string_view filename = "types.unordered_map.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeUnorderedMapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeUnorderedMapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMapField(*model, "Index32",
+                                       ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMapField(*model, "Index64",
+                                       ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeUnorderedMapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeUnorderedMapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedMapField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedMapField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", {{"aa", 1}}}};

--- a/types/unordered_multimap/fundamental/read.C
+++ b/types/unordered_multimap/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using UnorderedMultimap = std::unordered_multimap<std::string, std::int32_t>;
 
-static void PrintMultimapValue(const REntry &entry, std::string_view name,
+static void PrintMultimapValue(const ROOT::REntry &entry, std::string_view name,
                                std::ostream &os, bool last = false) {
   UnorderedMultimap &item = *entry.GetPtr<UnorderedMultimap>(name);
 
@@ -48,7 +45,7 @@ void read(
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_multimap/fundamental/read.C
+++ b/types/unordered_multimap/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/unordered_multimap/fundamental/write.C
+++ b/types/unordered_multimap/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_multimap/fundamental/write.C
+++ b/types/unordered_multimap/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using UnorderedMultimap = std::unordered_multimap<std::string, std::int32_t>;
 
-static std::shared_ptr<UnorderedMultimap> MakeMultimapField(RNTupleModel &model,
-                                                  std::string_view name,
-                                                  ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMultimap>>(name);
+static std::shared_ptr<UnorderedMultimap>
+MakeMultimapField(ROOT::RNTupleModel &model, std::string_view name,
+                  ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMultimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMultimap>(name);
 }
 
 void write(std::string_view filename = "types.unordered_multimap.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeMultimapField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeMultimapField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeMultimapField(*model, "SplitIndex32",
+                                        ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeMultimapField(*model, "SplitIndex64",
+                                        ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", 1}};

--- a/types/unordered_multimap/fundamental/write.C
+++ b/types/unordered_multimap/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using UnorderedMultimap = std::unordered_multimap<std::string, std::int32_t>;
 
 static std::shared_ptr<UnorderedMultimap> MakeMultimapField(RNTupleModel &model,
                                                   std::string_view name,
-                                                  EColumnType indexType) {
+                                                  ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMultimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.unordered_multimap.fundamental.roo
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeMultimapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeMultimapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeMultimapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeMultimapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_multimap/nested/read.C
+++ b/types/unordered_multimap/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/unordered_multimap/nested/read.C
+++ b/types/unordered_multimap/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -18,7 +15,7 @@ using UnorderedMultimap =
     std::unordered_multimap<std::string,
                             std::unordered_multimap<std::string, std::int32_t>>;
 
-static void PrintNestedUnorderedMultimapValue(const REntry &entry,
+static void PrintNestedUnorderedMultimapValue(const ROOT::REntry &entry,
                                               std::string_view name,
                                               std::ostream &os,
                                               bool last = false) {
@@ -80,7 +77,7 @@ void read(std::string_view input = "types.unordered_multimap.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_multimap/nested/write.C
+++ b/types/unordered_multimap/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -21,10 +15,10 @@ using ROOT::RNTupleWriter;
 using UnorderedMultimap = std::unordered_multimap<std::string,
                                std::unordered_multimap<std::string, std::int32_t>>;
 
-static std::shared_ptr<UnorderedMultimap> MakeUnorderedMultimapField(RNTupleModel &model,
-                                         std::string_view name,
-                                         ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMultimap>>(name);
+static std::shared_ptr<UnorderedMultimap>
+MakeUnorderedMultimapField(ROOT::RNTupleModel &model, std::string_view name,
+                           ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMultimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]
       ->GetMutableSubfields()[1]
@@ -38,22 +32,24 @@ void write(std::string_view filename = "types.unordered_multimap.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeUnorderedMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeUnorderedMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMultimapField(*model, "Index32",
+                                            ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMultimapField(*model, "Index64",
+                                            ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeUnorderedMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeUnorderedMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedMultimapField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedMultimapField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element maps, with ascending values
   *Index32 = {{"a", {{"aa", 1}}}};

--- a/types/unordered_multimap/nested/write.C
+++ b/types/unordered_multimap/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_multimap/nested/write.C
+++ b/types/unordered_multimap/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -23,11 +23,12 @@ using UnorderedMultimap = std::unordered_multimap<std::string,
 
 static std::shared_ptr<UnorderedMultimap> MakeUnorderedMultimapField(RNTupleModel &model,
                                          std::string_view name,
-                                         EColumnType indexType) {
+                                         ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMultimap>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->GetSubFields()[1]->SetColumnRepresentatives(
-      {{indexType}});
+  field->GetMutableSubfields()[0]
+      ->GetMutableSubfields()[1]
+      ->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMultimap>(name);
 }
@@ -40,14 +41,14 @@ void write(std::string_view filename = "types.unordered_multimap.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeUnorderedMultimapField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeUnorderedMultimapField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMultimapField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMultimapField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeUnorderedMultimapField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeUnorderedMultimapField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeUnorderedMultimapField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeUnorderedMultimapField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_multiset/fundamental/read.C
+++ b/types/unordered_multiset/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/unordered_multiset/fundamental/read.C
+++ b/types/unordered_multiset/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using UnorderedMultiSet = std::unordered_multiset<std::int32_t>;
 
-static void PrintUnorderedMultiSetValue(const REntry &entry,
+static void PrintUnorderedMultiSetValue(const ROOT::REntry &entry,
                                         std::string_view name, std::ostream &os,
                                         bool last = false) {
   UnorderedMultiSet &value = *entry.GetPtr<UnorderedMultiSet>(name);
@@ -47,7 +44,7 @@ void read(
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_multiset/fundamental/write.C
+++ b/types/unordered_multiset/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_multiset/fundamental/write.C
+++ b/types/unordered_multiset/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -18,9 +12,9 @@ using ROOT::RNTupleWriter;
 using UnorderedMultiSet = std::unordered_multiset<std::int32_t>;
 
 static std::shared_ptr<UnorderedMultiSet>
-MakeUnorderedMultiSetField(RNTupleModel &model, std::string_view name,
-                           ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMultiSet>>(name);
+MakeUnorderedMultiSetField(ROOT::RNTupleModel &model, std::string_view name,
+                           ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMultiSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMultiSet>(name);
@@ -28,24 +22,24 @@ MakeUnorderedMultiSetField(RNTupleModel &model, std::string_view name,
 
 void write(
     std::string_view filename = "types.unordered_multiset.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 =
-      MakeUnorderedMultiSetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 =
-      MakeUnorderedMultiSetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMultiSetField(*model, "Index32",
+                                            ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMultiSetField(*model, "Index64",
+                                            ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 = MakeUnorderedMultiSetField(*model, "SplitIndex32",
-                                                 ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 = MakeUnorderedMultiSetField(*model, "SplitIndex64",
-                                                 ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedMultiSetField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedMultiSetField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {1};

--- a/types/unordered_multiset/fundamental/write.C
+++ b/types/unordered_multiset/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using UnorderedMultiSet = std::unordered_multiset<std::int32_t>;
 
 static std::shared_ptr<UnorderedMultiSet>
 MakeUnorderedMultiSetField(RNTupleModel &model, std::string_view name,
-                           EColumnType indexType) {
+                           ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMultiSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -32,15 +32,15 @@ void write(
 
   // Non-split index encoding
   auto Index32 =
-      MakeUnorderedMultiSetField(*model, "Index32", EColumnType::kIndex32);
+      MakeUnorderedMultiSetField(*model, "Index32", ENTupleColumnType::kIndex32);
   auto Index64 =
-      MakeUnorderedMultiSetField(*model, "Index64", EColumnType::kIndex64);
+      MakeUnorderedMultiSetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 = MakeUnorderedMultiSetField(*model, "SplitIndex32",
-                                                 EColumnType::kSplitIndex32);
+                                                 ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 = MakeUnorderedMultiSetField(*model, "SplitIndex64",
-                                                 EColumnType::kSplitIndex64);
+                                                 ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_multiset/nested/read.C
+++ b/types/unordered_multiset/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/unordered_multiset/nested/read.C
+++ b/types/unordered_multiset/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -17,7 +14,7 @@ using ROOT::RNTupleReader;
 using UnorderedMultiset =
     std::unordered_multiset<std::unordered_multiset<std::int32_t>>;
 
-static void PrintNestedUnorderedMultisetValue(const REntry &entry,
+static void PrintNestedUnorderedMultisetValue(const ROOT::REntry &entry,
                                               std::string_view name,
                                               std::ostream &os,
                                               bool last = false) {
@@ -76,7 +73,7 @@ void read(std::string_view input = "types.unordered_multiset.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_multiset/nested/write.C
+++ b/types/unordered_multiset/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_multiset/nested/write.C
+++ b/types/unordered_multiset/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -24,9 +18,9 @@ using UnorderedMultiset =
     std::unordered_multiset<std::unordered_multiset<std::int32_t>>;
 
 static std::shared_ptr<UnorderedMultiset>
-MakeUnorderedMultisetField(RNTupleModel &model, std::string_view name,
-                           ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedMultiset>>(name);
+MakeUnorderedMultisetField(ROOT::RNTupleModel &model, std::string_view name,
+                           ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedMultiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -38,24 +32,24 @@ void write(std::string_view filename = "types.unordered_multiset.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 =
-      MakeUnorderedMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 =
-      MakeUnorderedMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedMultisetField(*model, "Index32",
+                                            ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedMultisetField(*model, "Index64",
+                                            ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 = MakeUnorderedMultisetField(*model, "SplitIndex32",
-                                                 ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 = MakeUnorderedMultisetField(*model, "SplitIndex64",
-                                                 ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedMultisetField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedMultisetField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {{1}};

--- a/types/unordered_multiset/nested/write.C
+++ b/types/unordered_multiset/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -25,10 +25,10 @@ using UnorderedMultiset =
 
 static std::shared_ptr<UnorderedMultiset>
 MakeUnorderedMultisetField(RNTupleModel &model, std::string_view name,
-                           EColumnType indexType) {
+                           ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedMultiset>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedMultiset>(name);
 }
@@ -42,15 +42,15 @@ void write(std::string_view filename = "types.unordered_multiset.nested.root") {
 
   // Non-split index encoding
   auto Index32 =
-      MakeUnorderedMultisetField(*model, "Index32", EColumnType::kIndex32);
+      MakeUnorderedMultisetField(*model, "Index32", ENTupleColumnType::kIndex32);
   auto Index64 =
-      MakeUnorderedMultisetField(*model, "Index64", EColumnType::kIndex64);
+      MakeUnorderedMultisetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 = MakeUnorderedMultisetField(*model, "SplitIndex32",
-                                                 EColumnType::kSplitIndex32);
+                                                 ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 = MakeUnorderedMultisetField(*model, "SplitIndex64",
-                                                 EColumnType::kSplitIndex64);
+                                                 ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_set/fundamental/read.C
+++ b/types/unordered_set/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,8 +10,9 @@ using ROOT::RNTupleReader;
 
 using UnorderedSet = std::unordered_set<std::int32_t>;
 
-static void PrintUnorderedSetValue(const REntry &entry, std::string_view name,
-                                   std::ostream &os, bool last = false) {
+static void PrintUnorderedSetValue(const ROOT::REntry &entry,
+                                   std::string_view name, std::ostream &os,
+                                   bool last = false) {
   UnorderedSet &value = *entry.GetPtr<UnorderedSet>(name);
 
   std::vector<UnorderedSet::value_type> valueSorted(value.begin(), value.end());
@@ -45,7 +43,7 @@ void read(std::string_view input = "types.unordered_set.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_set/fundamental/read.C
+++ b/types/unordered_set/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/unordered_set/fundamental/write.C
+++ b/types/unordered_set/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_set/fundamental/write.C
+++ b/types/unordered_set/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using UnorderedSet = std::unordered_set<std::int32_t>;
 
 static std::shared_ptr<UnorderedSet>
 MakeUnorderedSetField(RNTupleModel &model, std::string_view name,
-                      EColumnType indexType) {
+                      ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -31,15 +31,15 @@ void write(std::string_view filename = "types.unordered_set.fundamental.root") {
 
   // Non-split index encoding
   auto Index32 =
-      MakeUnorderedSetField(*model, "Index32", EColumnType::kIndex32);
+      MakeUnorderedSetField(*model, "Index32", ENTupleColumnType::kIndex32);
   auto Index64 =
-      MakeUnorderedSetField(*model, "Index64", EColumnType::kIndex64);
+      MakeUnorderedSetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeUnorderedSetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeUnorderedSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeUnorderedSetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeUnorderedSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/unordered_set/fundamental/write.C
+++ b/types/unordered_set/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -18,33 +12,33 @@ using ROOT::RNTupleWriter;
 using UnorderedSet = std::unordered_set<std::int32_t>;
 
 static std::shared_ptr<UnorderedSet>
-MakeUnorderedSetField(RNTupleModel &model, std::string_view name,
-                      ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedSet>>(name);
+MakeUnorderedSetField(ROOT::RNTupleModel &model, std::string_view name,
+                      ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedSet>(name);
 }
 
 void write(std::string_view filename = "types.unordered_set.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 =
-      MakeUnorderedSetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 =
-      MakeUnorderedSetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedSetField(*model, "Index32",
+                                       ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedSetField(*model, "Index64",
+                                       ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeUnorderedSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeUnorderedSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedSetField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedSetField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {1};

--- a/types/unordered_set/nested/read.C
+++ b/types/unordered_set/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/unordered_set/nested/read.C
+++ b/types/unordered_set/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -16,7 +13,7 @@ using ROOT::RNTupleReader;
 
 using UnorderedSet = std::unordered_set<std::unordered_set<std::int32_t>>;
 
-static void PrintNestedUnorderedSetValue(const REntry &entry,
+static void PrintNestedUnorderedSetValue(const ROOT::REntry &entry,
                                          std::string_view name,
                                          std::ostream &os, bool last = false) {
   UnorderedSet &value = *entry.GetPtr<UnorderedSet>(name);
@@ -73,7 +70,7 @@ void read(std::string_view input = "types.unordered_set.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/unordered_set/nested/write.C
+++ b/types/unordered_set/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -23,9 +17,9 @@ using ROOT::RNTupleWriter;
 using UnorderedSet = std::unordered_set<std::unordered_set<std::int32_t>>;
 
 static std::shared_ptr<UnorderedSet>
-MakeUnorderedSetField(RNTupleModel &model, std::string_view name,
-                      ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<UnorderedSet>>(name);
+MakeUnorderedSetField(ROOT::RNTupleModel &model, std::string_view name,
+                      ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<UnorderedSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -37,24 +31,24 @@ void write(std::string_view filename = "types.unordered_set.nested.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 =
-      MakeUnorderedSetField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 =
-      MakeUnorderedSetField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 = MakeUnorderedSetField(*model, "Index32",
+                                       ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 = MakeUnorderedSetField(*model, "Index64",
+                                       ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeUnorderedSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeUnorderedSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeUnorderedSetField(
+      *model, "SplitIndex32", ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeUnorderedSetField(
+      *model, "SplitIndex64", ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element sets, with ascending values
   *Index32 = {{1}};

--- a/types/unordered_set/nested/write.C
+++ b/types/unordered_set/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/unordered_set/nested/write.C
+++ b/types/unordered_set/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 
@@ -24,10 +24,10 @@ using UnorderedSet = std::unordered_set<std::unordered_set<std::int32_t>>;
 
 static std::shared_ptr<UnorderedSet>
 MakeUnorderedSetField(RNTupleModel &model, std::string_view name,
-                      EColumnType indexType) {
+                      ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<UnorderedSet>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<UnorderedSet>(name);
 }
@@ -41,15 +41,15 @@ void write(std::string_view filename = "types.unordered_set.nested.root") {
 
   // Non-split index encoding
   auto Index32 =
-      MakeUnorderedSetField(*model, "Index32", EColumnType::kIndex32);
+      MakeUnorderedSetField(*model, "Index32", ENTupleColumnType::kIndex32);
   auto Index64 =
-      MakeUnorderedSetField(*model, "Index64", EColumnType::kIndex64);
+      MakeUnorderedSetField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeUnorderedSetField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeUnorderedSetField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeUnorderedSetField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeUnorderedSetField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/user/class/read.C
+++ b/types/user/class/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/user/class/read.C
+++ b/types/user/class/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -51,7 +48,7 @@ static void PrintUserMembers(const User &value, std::ostream &os,
   os << indent << "}\n";
 }
 
-static void PrintUserValue(const REntry &entry, std::string_view name,
+static void PrintUserValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   auto &value = *entry.GetPtr<User>(name);
   os << "    \"" << name << "\": {\n";
@@ -63,7 +60,7 @@ static void PrintUserValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintUserVector(const REntry &entry, std::string_view name,
+static void PrintUserVector(const ROOT::REntry &entry, std::string_view name,
                             std::ostream &os, bool last = false) {
   auto &vector = *entry.GetPtr<std::vector<User>>(name);
   os << "    \"" << name << "\": [";
@@ -97,7 +94,7 @@ void read(std::string_view input = "types.user.class.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/user/class/write.C
+++ b/types/user/class/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 

--- a/types/user/class/write.C
+++ b/types/user/class/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <string_view>
@@ -17,15 +13,15 @@ void write(std::string_view filename = "types.user.class.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto value = model->MakeField<User>("f");
   auto vector = model->MakeField<std::vector<User>>("Vector");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   value->fInt = 1;

--- a/types/user/enum/read.C
+++ b/types/user/enum/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <TSystem.h>
 

--- a/types/user/enum/read.C
+++ b/types/user/enum/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <TSystem.h>
 
 #include <cstdint>
@@ -16,7 +13,7 @@ using ROOT::RNTupleReader;
 #include "UserEnum.hxx"
 
 template <typename T>
-static void PrintEnumValue(const REntry &entry, std::string_view name,
+static void PrintEnumValue(const ROOT::REntry &entry, std::string_view name,
                            std::ostream &os, bool last = false) {
   T value = *entry.GetPtr<T>(name);
   os << "    \"" << name << "\": ";
@@ -38,7 +35,7 @@ void read(std::string_view input = "types.user.enum.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/user/enum/write.C
+++ b/types/user/enum/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <TSystem.h>
 
 #include <string_view>
@@ -17,7 +13,7 @@ void write(std::string_view filename = "types.user.enum.root") {
     throw std::runtime_error("could not find the required ROOT dictionaries, "
                              "please make sure to run `make` first");
 
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // TODO: enums with bool underlying type are possible since ROOT 6.38
   auto EInt8 = model->MakeField<EnumInt8>("EnumInt8");
@@ -29,10 +25,10 @@ void write(std::string_view filename = "types.user.enum.root") {
   auto EInt64 = model->MakeField<EnumInt64>("EnumInt64");
   auto EUInt64 = model->MakeField<EnumUInt64>("EnumUInt64");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: simple values
   *EInt8 = EnumInt8::Simple;     // = 1;

--- a/types/user/enum/write.C
+++ b/types/user/enum/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <TSystem.h>
 

--- a/types/variant/read.C
+++ b/types/variant/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -16,7 +13,7 @@ using VectorInt32 = std::vector<std::int32_t>;
 using Variant = std::variant<std::int32_t, std::string, VectorInt32>;
 using Vector = std::vector<std::variant<std::int32_t, std::string>>;
 
-static void PrintVariantValue(const REntry &entry, std::string_view name,
+static void PrintVariantValue(const ROOT::REntry &entry, std::string_view name,
                               std::ostream &os, bool last = false) {
   Variant &value = *entry.GetPtr<Variant>(name);
   os << "    \"" << name << "\": ";
@@ -48,7 +45,7 @@ static void PrintVariantValue(const REntry &entry, std::string_view name,
   os << "\n";
 }
 
-static void PrintVectorValue(const REntry &entry, std::string_view name,
+static void PrintVectorValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
@@ -82,7 +79,7 @@ void read(std::string_view input = "types.variant.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/variant/read.C
+++ b/types/variant/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/variant/write.C
+++ b/types/variant/write.C
@@ -2,9 +2,9 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <string>

--- a/types/variant/write.C
+++ b/types/variant/write.C
@@ -2,10 +2,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -17,15 +13,15 @@ using Variant = std::variant<std::int32_t, std::string, VectorInt32>;
 using Vector = std::vector<std::variant<std::int32_t, std::string>>;
 
 void write(std::string_view filename = "types.variant.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   auto value = model->MakeField<Variant>("f");
   auto vector = model->MakeField<Vector>("Vector");
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: std::int32_t
   *value = 1;

--- a/types/vector/fundamental/read.C
+++ b/types/vector/fundamental/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,7 +10,7 @@ using ROOT::RNTupleReader;
 
 using Vector = std::vector<std::int32_t>;
 
-static void PrintVectorValue(const REntry &entry, std::string_view name,
+static void PrintVectorValue(const ROOT::REntry &entry, std::string_view name,
                              std::ostream &os, bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
@@ -41,7 +38,7 @@ void read(std::string_view input = "types.vector.fundamental.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/vector/fundamental/read.C
+++ b/types/vector/fundamental/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/vector/fundamental/write.C
+++ b/types/vector/fundamental/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,7 +19,7 @@ using Vector = std::vector<std::int32_t>;
 
 static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType indexType) {
+                                               ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -30,14 +30,14 @@ void write(std::string_view filename = "types.vector.fundamental.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/vector/fundamental/write.C
+++ b/types/vector/fundamental/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -17,32 +11,34 @@ using ROOT::RNTupleWriter;
 
 using Vector = std::vector<std::int32_t>;
 
-static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
-                                               std::string_view name,
-                                               ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Vector>>(name);
+static std::shared_ptr<Vector>
+MakeVectorField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Vector>(name);
 }
 
 void write(std::string_view filename = "types.vector.fundamental.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeVectorField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeVectorField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeVectorField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeVectorField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element vectors, with ascending values
   *Index32 = {1};

--- a/types/vector/fundamental/write.C
+++ b/types/vector/fundamental/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/vector/nested/read.C
+++ b/types/vector/nested/read.C
@@ -1,8 +1,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleReader;
+using ROOT::REntry;
+using ROOT::RNTupleReader;
 
 #include <cstdint>
 #include <fstream>

--- a/types/vector/nested/read.C
+++ b/types/vector/nested/read.C
@@ -1,9 +1,6 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleReader.hxx>
 
-using ROOT::REntry;
-using ROOT::RNTupleReader;
-
 #include <cstdint>
 #include <fstream>
 #include <ostream>
@@ -13,8 +10,9 @@ using ROOT::RNTupleReader;
 
 using Vector = std::vector<std::vector<std::int32_t>>;
 
-static void PrintNestedVectorValue(const REntry &entry, std::string_view name,
-                                   std::ostream &os, bool last = false) {
+static void PrintNestedVectorValue(const ROOT::REntry &entry,
+                                   std::string_view name, std::ostream &os,
+                                   bool last = false) {
   Vector &value = *entry.GetPtr<Vector>(name);
   os << "    \"" << name << "\": [";
   bool outerFirst = true;
@@ -54,7 +52,7 @@ void read(std::string_view input = "types.vector.nested.root",
   std::ofstream os(std::string{output});
   os << "[\n";
 
-  auto reader = RNTupleReader::Open("ntpl", input);
+  auto reader = ROOT::RNTupleReader::Open("ntpl", input);
   auto &entry = reader->GetModel().GetDefaultEntry();
   bool first = true;
   for (auto index : *reader) {

--- a/types/vector/nested/write.C
+++ b/types/vector/nested/write.C
@@ -4,11 +4,11 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::Experimental::EColumnType;
-using ROOT::Experimental::RField;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::ENTupleColumnType;
+using ROOT::RField;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 #include <cstdint>
 #include <memory>
@@ -19,10 +19,10 @@ using Vector = std::vector<std::vector<std::int32_t>>;
 
 static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
                                                std::string_view name,
-                                               EColumnType indexType) {
+                                               ENTupleColumnType indexType) {
   auto field = std::make_unique<RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
-  field->GetSubFields()[0]->SetColumnRepresentatives({{indexType}});
+  field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
   return model.GetDefaultEntry().GetPtr<Vector>(name);
 }
@@ -31,14 +31,14 @@ void write(std::string_view filename = "types.vector.nested.root") {
   auto model = RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", EColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", EColumnType::kIndex64);
+  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
+  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
 
   // Split index encoding
   auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", EColumnType::kSplitIndex32);
+      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
   auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", EColumnType::kSplitIndex64);
+      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
 
   RNTupleWriteOptions options;
   options.SetCompression(0);

--- a/types/vector/nested/write.C
+++ b/types/vector/nested/write.C
@@ -1,6 +1,10 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if __has_include(<ROOT/RNTupleTypes.hxx>)
+#include <ROOT/RNTupleTypes.hxx>
+#else
 #include <ROOT/RNTupleUtil.hxx>
+#endif
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 

--- a/types/vector/nested/write.C
+++ b/types/vector/nested/write.C
@@ -4,12 +4,6 @@
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
-using ROOT::ENTupleColumnType;
-using ROOT::RField;
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriteOptions;
-using ROOT::RNTupleWriter;
-
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -17,10 +11,10 @@ using ROOT::RNTupleWriter;
 
 using Vector = std::vector<std::vector<std::int32_t>>;
 
-static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
-                                               std::string_view name,
-                                               ENTupleColumnType indexType) {
-  auto field = std::make_unique<RField<Vector>>(name);
+static std::shared_ptr<Vector>
+MakeVectorField(ROOT::RNTupleModel &model, std::string_view name,
+                ROOT::ENTupleColumnType indexType) {
+  auto field = std::make_unique<ROOT::RField<Vector>>(name);
   field->SetColumnRepresentatives({{indexType}});
   field->GetMutableSubfields()[0]->SetColumnRepresentatives({{indexType}});
   model.AddField(std::move(field));
@@ -28,22 +22,24 @@ static std::shared_ptr<Vector> MakeVectorField(RNTupleModel &model,
 }
 
 void write(std::string_view filename = "types.vector.nested.root") {
-  auto model = RNTupleModel::Create();
+  auto model = ROOT::RNTupleModel::Create();
 
   // Non-split index encoding
-  auto Index32 = MakeVectorField(*model, "Index32", ENTupleColumnType::kIndex32);
-  auto Index64 = MakeVectorField(*model, "Index64", ENTupleColumnType::kIndex64);
+  auto Index32 =
+      MakeVectorField(*model, "Index32", ROOT::ENTupleColumnType::kIndex32);
+  auto Index64 =
+      MakeVectorField(*model, "Index64", ROOT::ENTupleColumnType::kIndex64);
 
   // Split index encoding
-  auto SplitIndex32 =
-      MakeVectorField(*model, "SplitIndex32", ENTupleColumnType::kSplitIndex32);
-  auto SplitIndex64 =
-      MakeVectorField(*model, "SplitIndex64", ENTupleColumnType::kSplitIndex64);
+  auto SplitIndex32 = MakeVectorField(*model, "SplitIndex32",
+                                      ROOT::ENTupleColumnType::kSplitIndex32);
+  auto SplitIndex64 = MakeVectorField(*model, "SplitIndex64",
+                                      ROOT::ENTupleColumnType::kSplitIndex64);
 
-  RNTupleWriteOptions options;
+  ROOT::RNTupleWriteOptions options;
   options.SetCompression(0);
-  auto writer =
-      RNTupleWriter::Recreate(std::move(model), "ntpl", filename, options);
+  auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl",
+                                              filename, options);
 
   // First entry: single-element vectors, with ascending values
   *Index32 = {{1}};


### PR DESCRIPTION
In a first step, change all using declarations to the `ROOT` namespace, rename `EColumnType` -> `ENTupleColumnType`, and update method calls from `GetSubFields()` to `GetMutableSubfields()`. Then replace the using declarations, and followup changes for compatibility with newer versions of ROOT.