### PR TITLE
Run validation suite on multiple versions and store them separately in folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ $(DICT_MAKEFILE_DIR)::
 .PHONY: write
 write:: $(WRITE_C)
 $(WRITE_C)::
-	@LD_LIBRARY_PATH=$(shell dirname $@) $(ROOT_EXE) -q -l $@
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(shell dirname $@)" $(ROOT_EXE) -q -l $@
 
 .PHONY: read
 read:: $(READ_C)
 $(READ_C)::
-	@LD_LIBRARY_PATH=$(shell dirname $@) $(ROOT_EXE) -q -l $@
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(shell dirname $@)" $(ROOT_EXE) -q -l $@

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,10 @@ ifeq ($(ROOT_EXE),)
 $(error Could not find root.exe)
 endif
 
-define move_files
-    mkdir -p $(1)_files && \
-    find . -name "*.$(1)" -not -path "./$(1)_files/*" -exec mv {} "$(1)_files" \;
-endef
-
-ver :=
-DICT_DIR := $(shell pwd)/dict/$(ver)/
+# directory arguments can be empty -> no sudirectories will be created, everything will be stored directly in those folders
+DICT_DIR := $(shell pwd)/dict/$(if $(dict_dir),$(dict_dir)/)
+WRITE_DIR := $(shell pwd)/write/$(if $(write_dir),$(write_dir)/)
+READ_DIR := $(shell pwd)/read/$(if $(write_dir),$(write_dir)/)$(if $(read_dir),$(read_dir)/)
 export DICT_DIR
 
 .PHONY: all
@@ -17,7 +14,6 @@ all:
 	$(MAKE) dict
 	$(MAKE) write
 	$(MAKE) read
-	$(MAKE) store
 
 # This assumes there is no whitespace in any of the paths...
 DICT_MAKEFILE_DIR := $(sort $(shell find */ -name Makefile -printf "%h\n"))
@@ -34,15 +30,17 @@ $(DICT_DIR)::
 
 .PHONY: write
 write:: $(WRITE_C)
-$(WRITE_C)::
-	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(or $(DICT_DIR),$(shell dirname $@))" $(ROOT_EXE) -q -l $@
+$(WRITE_C):: $(WRITE_DIR)
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l '$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root")'
+$(WRITE_DIR)::
+	@mkdir -p $@
+	$(info Storing root files in: '$@')
 
 .PHONY: read
 read:: $(READ_C)
-$(READ_C)::
-	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(or $(DICT_DIR),$(shell dirname $@))" $(ROOT_EXE) -q -l $@
-
-.PHONY: store
-store:
-	@$(call move_files,root)
-	@$(call move_files,json)
+$(READ_C):: $(READ_DIR)
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l \
+	'$@("$(WRITE_DIR)/$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
+$(READ_DIR)::
+	@mkdir -p $@
+	$(info Storing root files in: '$@')

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,21 @@ ifeq ($(ROOT_EXE),)
 $(error Could not find root.exe)
 endif
 
+define move_files
+    mkdir -p $(1)_files && \
+    find . -name "*.$(1)" -not -path "./$(1)_files/*" -exec mv {} "$(1)_files" \;
+endef
+
+ver :=
+DICT_DIR := $(shell pwd)/dict/$(ver)/
+export DICT_DIR
+
 .PHONY: all
 all:
 	$(MAKE) dict
 	$(MAKE) write
 	$(MAKE) read
+	$(MAKE) store
 
 # This assumes there is no whitespace in any of the paths...
 DICT_MAKEFILE_DIR := $(sort $(shell find */ -name Makefile -printf "%h\n"))
@@ -16,15 +26,23 @@ READ_C := $(sort $(shell find . -name read.C))
 
 .PHONY: dict
 dict:: $(DICT_MAKEFILE_DIR)
-$(DICT_MAKEFILE_DIR)::
+$(DICT_MAKEFILE_DIR):: $(DICT_DIR)
 	@$(MAKE) -C $@
+$(DICT_DIR)::
+	@mkdir -p $@
+	$(info Storing dictionaries in: '$@')
 
 .PHONY: write
 write:: $(WRITE_C)
 $(WRITE_C)::
-	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(shell dirname $@)" $(ROOT_EXE) -q -l $@
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(or $(DICT_DIR),$(shell dirname $@))" $(ROOT_EXE) -q -l $@
 
 .PHONY: read
 read:: $(READ_C)
 $(READ_C)::
-	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(shell dirname $@)" $(ROOT_EXE) -q -l $@
+	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(or $(DICT_DIR),$(shell dirname $@))" $(ROOT_EXE) -q -l $@
+
+.PHONY: store
+store:
+	@$(call move_files,root)
+	@$(call move_files,json)

--- a/README.md
+++ b/README.md
@@ -30,3 +30,31 @@ They can be run individually or all at once with `make` using the top-level [`Ma
 The latter is also exercised by a GitHub Actions Workflow:
 ![Execute ROOT macros](https://github.com/root-project/rntuple-validation/actions/workflows/root.yml/badge.svg)
 The job also uploads the produced set of `.root` and `.json` files, which can be downloaded from the Summary page.
+
+Running the complete Validation Suite with `make` creates three folders:
+- _dict_: contains the produced dictionaries (`.so`, `.pcm` and `.cxx` files)
+- _write_: contains the produced `.root` files
+- _read_: contains the produced `.json` files
+
+Each operation can also be run individually, i.e. `make dict`, `make write` and `make read`.
+
+To store results separately per version, subdirectories can be defined via the `dict_dir`, `write_dir` or `read_dir` arguments. Note that `read_dir` creates a subdirectory inside the folder named by `write_dir` within _read_. For example:
+```
+make dict_dir=6.38.00 write_dir=6.38.00 read_dir=6.38.00
+```
+produces the following structure:
+```
+dict/
+├── 6.38.00/
+    ├── .so
+    ├── .pcm
+    └── .cxx
+write/
+├── 6.38.00/
+    └── .root
+read/
+├── 6.38.00/     <- version that wrote the .root files (write_dir)
+    └── 6.38.00/ <- version that read them and produced the .json files (read_dir)
+        └── .json
+```
+The two-level hierarchy in _read_ reflects the cross-validation between ROOT versions: the outer directory identifies the version whose `.root` files were used as input, and the inner directory identifies the version that read them and produced the `.json` output.

--- a/types/map/nested/Makefile
+++ b/types/map/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedMap.cxx: NestedMap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^ 
 
 $(DICT_DIR)libNestedMap.so: $(DICT_DIR)NestedMap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedMap.cxx NestedMap_rdict.pcm libNestedMap.so

--- a/types/map/nested/Makefile
+++ b/types/map/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedMap.so
+all: $(DICT_DIR)libNestedMap.so
 
-NestedMap.cxx: NestedMap.hxx LinkDef.h
-	$(ROOTCLING) -f $@ $^
+$(DICT_DIR)NestedMap.cxx: NestedMap.hxx LinkDef.h
+	$(ROOTCLING) -f $@ $^ 
 
-libNestedMap.so: NestedMap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedMap.so: $(DICT_DIR)NestedMap.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedMap.cxx NestedMap_rdict.pcm libNestedMap.so

--- a/types/multimap/nested/Makefile
+++ b/types/multimap/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedMultimap.so
+all: $(DICT_DIR)libNestedMultimap.so
 
-NestedMultimap.cxx: NestedMultimap.hxx LinkDef.h
+$(DICT_DIR)NestedMultimap.cxx: NestedMultimap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedMultimap.so: NestedMultimap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedMultimap.so: $(DICT_DIR)NestedMultimap.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedMultimap.cxx NestedMultimap_rdict.pcm libNestedMultimap.so

--- a/types/multimap/nested/Makefile
+++ b/types/multimap/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedMultimap.cxx: NestedMultimap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedMultimap.so: $(DICT_DIR)NestedMultimap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedMultimap.cxx NestedMultimap_rdict.pcm libNestedMultimap.so

--- a/types/multiset/nested/Makefile
+++ b/types/multiset/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedMultiset.so
+all: $(DICT_DIR)libNestedMultiset.so
 
-NestedMultiset.cxx: NestedMultiset.hxx LinkDef.h
+$(DICT_DIR)NestedMultiset.cxx: NestedMultiset.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedMultiset.so: NestedMultiset.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedMultiset.so: $(DICT_DIR)NestedMultiset.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedMultiset.cxx NestedMultiset_rdict.pcm libNestedMultiset.so

--- a/types/multiset/nested/Makefile
+++ b/types/multiset/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedMultiset.cxx: NestedMultiset.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedMultiset.so: $(DICT_DIR)NestedMultiset.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedMultiset.cxx NestedMultiset_rdict.pcm libNestedMultiset.so

--- a/types/set/nested/Makefile
+++ b/types/set/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedSet.cxx: NestedSet.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedSet.so: $(DICT_DIR)NestedSet.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedSet.cxx NestedSet_rdict.pcm libNestedSet.so

--- a/types/set/nested/Makefile
+++ b/types/set/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedSet.so
+all: $(DICT_DIR)libNestedSet.so
 
-NestedSet.cxx: NestedSet.hxx LinkDef.h
+$(DICT_DIR)NestedSet.cxx: NestedSet.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedSet.so: NestedSet.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedSet.so: $(DICT_DIR)NestedSet.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedSet.cxx NestedSet_rdict.pcm libNestedSet.so

--- a/types/unordered_map/nested/Makefile
+++ b/types/unordered_map/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedUnorderedMap.so
+all: $(DICT_DIR)libNestedUnorderedMap.so
 
-NestedUnorderedMap.cxx: NestedUnorderedMap.hxx LinkDef.h
+$(DICT_DIR)NestedUnorderedMap.cxx: NestedUnorderedMap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedUnorderedMap.so: NestedUnorderedMap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedUnorderedMap.so: $(DICT_DIR)NestedUnorderedMap.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedUnorderedMap.cxx NestedUnorderedMap_rdict.pcm libNestedUnorderedMap.so

--- a/types/unordered_map/nested/Makefile
+++ b/types/unordered_map/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedUnorderedMap.cxx: NestedUnorderedMap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedUnorderedMap.so: $(DICT_DIR)NestedUnorderedMap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedUnorderedMap.cxx NestedUnorderedMap_rdict.pcm libNestedUnorderedMap.so

--- a/types/unordered_multimap/nested/Makefile
+++ b/types/unordered_multimap/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedUnorderedMultimap.so
+all: $(DICT_DIR)libNestedUnorderedMultimap.so
 
-NestedUnorderedMultimap.cxx: NestedUnorderedMultimap.hxx LinkDef.h
+$(DICT_DIR)NestedUnorderedMultimap.cxx: NestedUnorderedMultimap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedUnorderedMultimap.so: NestedUnorderedMultimap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedUnorderedMultimap.so: $(DICT_DIR)NestedUnorderedMultimap.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedUnorderedMultimap.cxx NestedUnorderedMultimap_rdict.pcm libNestedUnorderedMultimap.so

--- a/types/unordered_multimap/nested/Makefile
+++ b/types/unordered_multimap/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedUnorderedMultimap.cxx: NestedUnorderedMultimap.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedUnorderedMultimap.so: $(DICT_DIR)NestedUnorderedMultimap.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedUnorderedMultimap.cxx NestedUnorderedMultimap_rdict.pcm libNestedUnorderedMultimap.so

--- a/types/unordered_multiset/nested/Makefile
+++ b/types/unordered_multiset/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedUnorderedMultiset.cxx: NestedUnorderedMultiset.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedUnorderedMultiset.so: $(DICT_DIR)NestedUnorderedMultiset.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedUnorderedMultiset.cxx NestedUnorderedMultiset_rdict.pcm libNestedUnorderedMultiset.so

--- a/types/unordered_multiset/nested/Makefile
+++ b/types/unordered_multiset/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedUnorderedMultiset.so
+all: $(DICT_DIR)libNestedUnorderedMultiset.so
 
-NestedUnorderedMultiset.cxx: NestedUnorderedMultiset.hxx LinkDef.h
+$(DICT_DIR)NestedUnorderedMultiset.cxx: NestedUnorderedMultiset.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedUnorderedMultiset.so: NestedUnorderedMultiset.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedUnorderedMultiset.so: $(DICT_DIR)NestedUnorderedMultiset.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedUnorderedMultiset.cxx NestedUnorderedMultiset_rdict.pcm libNestedUnorderedMultiset.so

--- a/types/unordered_set/nested/Makefile
+++ b/types/unordered_set/nested/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libNestedUnorderedSet.so
+all: $(DICT_DIR)libNestedUnorderedSet.so
 
-NestedUnorderedSet.cxx: NestedUnorderedSet.hxx LinkDef.h
+$(DICT_DIR)NestedUnorderedSet.cxx: NestedUnorderedSet.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libNestedUnorderedSet.so: NestedUnorderedSet.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libNestedUnorderedSet.so: $(DICT_DIR)NestedUnorderedSet.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) NestedUnorderedSet.cxx NestedUnorderedSet_rdict.pcm libNestedUnorderedSet.so

--- a/types/unordered_set/nested/Makefile
+++ b/types/unordered_set/nested/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)NestedUnorderedSet.cxx: NestedUnorderedSet.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libNestedUnorderedSet.so: $(DICT_DIR)NestedUnorderedSet.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) NestedUnorderedSet.cxx NestedUnorderedSet_rdict.pcm libNestedUnorderedSet.so

--- a/types/user/class/Makefile
+++ b/types/user/class/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libUserClass.so
+all: $(DICT_DIR)libUserClass.so
 
-UserClass.cxx: UserClass.hxx LinkDef.h
+$(DICT_DIR)UserClass.cxx: UserClass.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libUserClass.so: UserClass.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libUserClass.so: $(DICT_DIR)UserClass.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) UserClass.cxx UserClass_rdict.pcm libUserClass.so

--- a/types/user/class/Makefile
+++ b/types/user/class/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)UserClass.cxx: UserClass.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libUserClass.so: $(DICT_DIR)UserClass.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) UserClass.cxx UserClass_rdict.pcm libUserClass.so

--- a/types/user/enum/Makefile
+++ b/types/user/enum/Makefile
@@ -14,13 +14,13 @@ LDFLAGS := $(shell $(ROOT_CONFIG) --libs)
 
 .PHONY: all clean
 
-all: libUserEnum.so
+all: $(DICT_DIR)libUserEnum.so
 
-UserEnum.cxx: UserEnum.hxx LinkDef.h
+$(DICT_DIR)UserEnum.cxx: UserEnum.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
-libUserEnum.so: UserEnum.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+$(DICT_DIR)libUserEnum.so: $(DICT_DIR)UserEnum.cxx
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
 
 clean:
 	$(RM) UserEnum.cxx UserEnum_rdict.pcm libUserEnum.so

--- a/types/user/enum/Makefile
+++ b/types/user/enum/Makefile
@@ -20,7 +20,7 @@ $(DICT_DIR)UserEnum.cxx: UserEnum.hxx LinkDef.h
 	$(ROOTCLING) -f $@ $^
 
 $(DICT_DIR)libUserEnum.so: $(DICT_DIR)UserEnum.cxx
-	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I $$(pwd)
+	$(CXX) -shared -fPIC -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -I .
 
 clean:
 	$(RM) UserEnum.cxx UserEnum_rdict.pcm libUserEnum.so


### PR DESCRIPTION
The validation suite can now be run by specifying folders for dictionaries, ROOT binary files and JSON files created accordingly. That way the `.root` files generated by version X can be read by other versions to create `.json` files.