### PR TITLE
Run validation suite with automated sourcing and cross-validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.so
 Nested*.cxx
 User*.cxx
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 ROOT_EXE ?= $(shell which root.exe)
-ifeq ($(ROOT_EXE),)
-$(error Could not find root.exe)
-endif
 
 # directory arguments can be empty -> no sudirectories will be created, everything will be stored directly in those folders
 DICT_DIR := $(shell pwd)/dict/$(if $(dict_dir),$(dict_dir)/)
@@ -10,7 +7,7 @@ READ_DIR := $(shell pwd)/read/$(if $(write_dir),$(write_dir)/)$(if $(read_dir),$
 export DICT_DIR
 
 .PHONY: all
-all:
+all: check
 	$(MAKE) dict
 	$(MAKE) write
 	$(MAKE) read
@@ -20,27 +17,58 @@ DICT_MAKEFILE_DIR := $(sort $(shell find */ -name Makefile -printf "%h\n"))
 WRITE_C := $(sort $(shell find . -name write.C))
 READ_C := $(sort $(shell find . -name read.C))
 
+# run each Makefile in subdirectories to create dictionaries
 .PHONY: dict
-dict:: $(DICT_MAKEFILE_DIR)
+dict:: check $(DICT_MAKEFILE_DIR)
 $(DICT_MAKEFILE_DIR):: $(DICT_DIR)
 	@$(MAKE) -C $@
 $(DICT_DIR)::
-	@mkdir -p $@
-	$(info Storing dictionaries in: '$@')
+	@echo -e "\nStarting dict target - Storing dictionaries in: '$@'" && mkdir -p $@
 
+# run each write.C file in subdirectories to create .root files
 .PHONY: write
-write:: $(WRITE_C)
+write:: check $(WRITE_C)
 $(WRITE_C):: $(WRITE_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l '$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root")'
 $(WRITE_DIR)::
-	@mkdir -p $@
-	$(info Storing root files in: '$@')
+	@echo -e "\nStarting write target - Storing root files in: '$@'" && mkdir -p $@
 
+# run each read.C file in subdirectories to create .json files
 .PHONY: read
-read:: $(READ_C)
+read:: check $(READ_C)
 $(READ_C):: $(READ_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l \
 	'$@("$(WRITE_DIR)/$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
 $(READ_DIR)::
-	@mkdir -p $@
-	$(info Storing root files in: '$@')
+	@echo -e "\nStarting read target - Storing json files in: '$@'" && mkdir -p $@
+
+.PHONY: check
+check::
+	@test -x "$(ROOT_EXE)" || { echo "Could not find root.exe"; exit 1; }
+
+.PHONY: validate
+validate:
+	@if [ "$(source_scripts)" = "" ]; then\
+        echo "Source scripts missing"; exit 1;\
+    fi
+
+#	run make dict to create dictionaries
+	@echo "-- Creating dictionaries --"
+	@for s_path in $(source_scripts); do \
+		(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) dict dict_dir=\$$ROOT_VERSION") || exit $$?; \
+	done
+
+#	run make write to create binaries
+	@echo "-- Creating binaries --"
+	@for s_path in $(source_scripts); do \
+		(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) write dict_dir=\$$ROOT_VERSION write_dir=\$$ROOT_VERSION") || exit $$?; \
+	done
+	
+#	run make read to do cross-validation
+	@echo "-- Creating .json files --"
+	@for s_path in $(source_scripts); do \
+		for w_dir in write/*; do \
+			(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) read dict_dir=\$$ROOT_VERSION write_dir=$$(basename $$w_dir) read_dir=\$$ROOT_VERSION") || exit $$?; \
+		done; \
+	done
+	@echo Finished

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 ROOT_EXE ?= $(shell which root.exe)
+ASSET_VERSION := 1.0.0
+ROOT_ASSET := RNTuple-ROOT-v$(ASSET_VERSION).zip 
+JSON_ASSET := Validation-JSON-v$(ASSET_VERSION).zip
 
 # directory arguments can be empty -> no sudirectories will be created, everything will be stored directly in those folders
 DICT_DIR := $(shell pwd)/dict/$(if $(dict_dir),$(dict_dir)/)
@@ -23,7 +26,7 @@ dict:: check $(DICT_MAKEFILE_DIR)
 $(DICT_MAKEFILE_DIR):: $(DICT_DIR)
 	@$(MAKE) -C $@
 $(DICT_DIR)::
-	@echo -e "\nStarting dict target - Storing dictionaries in: '$@'" && mkdir -p $@
+	@echo "\nStarting dict target - Storing dictionaries in: '$@'" && mkdir -p $@
 
 # run each write.C file in subdirectories to create .root files
 .PHONY: write
@@ -31,16 +34,16 @@ write:: check $(WRITE_C)
 $(WRITE_C):: $(WRITE_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l '$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root")'
 $(WRITE_DIR)::
-	@echo -e "\nStarting write target - Storing root files in: '$@'" && mkdir -p $@
+	@echo "\nStarting write target - Storing root files in: '$@'" && mkdir -p $@
 
 # run each read.C file in subdirectories to create .json files
 .PHONY: read
 read:: check $(READ_C)
 $(READ_C):: $(READ_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l \
-	'$@("$(WRITE_DIR)/$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
+	'$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
 $(READ_DIR)::
-	@echo -e "\nStarting read target - Storing json files in: '$@'" && mkdir -p $@
+	@echo "\nStarting read target - Storing json files in: '$@'" && mkdir -p $@
 
 .PHONY: check
 check::
@@ -72,3 +75,10 @@ validate:
 		done; \
 	done
 	@echo Finished
+
+download: 
+	@echo "Downloading and unpacking assets from GitHub.."
+	@wget -q -N -P ./assets https://github.com/root-project/rntuple-validation/releases/download/v$(ASSET_VERSION)/$(ROOT_ASSET)
+	@mkdir -p write && unzip -n -q -d write/$(basename $(ROOT_ASSET)) assets/$(ROOT_ASSET)
+	@wget -q -N -P ./assets https://github.com/root-project/rntuple-validation/releases/download/v$(ASSET_VERSION)/$(JSON_ASSET)
+	@mkdir -p read/$(basename $(ROOT_ASSET)) && unzip -n -q -d read/$(basename $(ROOT_ASSET))/$(basename $(JSON_ASSET)) assets/$(JSON_ASSET)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ read/
 ```
 The two-level hierarchy in _read_ reflects the cross-validation between ROOT versions: the outer directory identifies the version whose `.root` files were used as input, and the inner directory identifies the version that read them and produced the `.json` output.
 
-Use `make validate` to automatically run the validation suite across multiple versions. For that, set `source_scripts` to the paths to source for each version, separated by spaces. The dictionaries and binaries are then built for each version, and each ROOT version is tested against every subdirectory found in _write_. \
+Use `make validate` to automatically run the validation suite across multiple versions. For that, set `source_scripts` to the paths to source for each version, separated by spaces. The dictionaries and binaries are then built for each version, and each ROOT version is tested against every subdirectory found in _write_. 
 
 For example:
 ```
 make validate source_dirs="<path_root_v1> <path_root_v2>"
 ```
+
+Run `make download` in advance to download the ROOT and JSON [assets](https://github.com/root-project/rntuple-validation/releases/) from GitHub. Asset version `1.0.0` is used as default. Set the `ASSET_VERSION` argument to use another version.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Running the complete Validation Suite with `make` creates three folders:
 - _write_: contains the produced `.root` files
 - _read_: contains the produced `.json` files
 
-Each operation can also be run individually, i.e. `make dict`, `make write` and `make read`.
+Each operation can also be run individually, i.e. `make dict`, `make write` and `make read`. A ROOT version needs to be available beforehand!
 
 To store results separately per version, subdirectories can be defined via the `dict_dir`, `write_dir` or `read_dir` arguments. Note that `read_dir` creates a subdirectory inside the folder named by `write_dir` within _read_. For example:
 ```
@@ -58,3 +58,10 @@ read/
         └── .json
 ```
 The two-level hierarchy in _read_ reflects the cross-validation between ROOT versions: the outer directory identifies the version whose `.root` files were used as input, and the inner directory identifies the version that read them and produced the `.json` output.
+
+Use `make validate` to automatically run the validation suite across multiple versions. For that, set `source_scripts` to the paths to source for each version, separated by spaces. The dictionaries and binaries are then built for each version, and each ROOT version is tested against every subdirectory found in _write_. \
+
+For example:
+```
+make validate source_dirs="<path_root_v1> <path_root_v2>"
+```


### PR DESCRIPTION
Added a new target `validate` that runs the validation suite automatically for several versions, by providing the paths to the source files. 