### PR TITLE
Correcting Makefile for parallelization and new files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,32 +22,32 @@ WRITE_C := $(sort $(shell find . -name write.C))
 READ_C := $(sort $(shell find . -name read.C))
 
 # run each Makefile in subdirectories to create dictionaries
-.PHONY: dict
-dict:: check $(DICT_MAKEFILE_DIR)
-$(DICT_MAKEFILE_DIR):: $(DICT_DIR)
+.PHONY: dict $(DICT_MAKEFILE_DIR) $(DICT_DIR)
+dict: check $(DICT_MAKEFILE_DIR)
+$(DICT_MAKEFILE_DIR): $(DICT_DIR)
 	@$(MAKE) -C $@
-$(DICT_DIR)::
+$(DICT_DIR):
 	@echo "\nStarting dict target - Storing dictionaries in: '$@'" && mkdir -p $@
 
 # run each write.C file in subdirectories to create .root files
-.PHONY: write
-write:: check $(WRITE_C)
-$(WRITE_C):: $(WRITE_DIR)
+.PHONY: write $(WRITE_C) $(WRITE_DIR)
+write: check $(WRITE_C)
+$(WRITE_C): $(WRITE_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l '$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root")'
-$(WRITE_DIR)::
+$(WRITE_DIR):
 	@echo "\nStarting write target - Storing root files in: '$@'" && mkdir -p $@
 
 # run each read.C file in subdirectories to create .json files
-.PHONY: read
-read:: check $(READ_C)
-$(READ_C):: $(READ_DIR)
+.PHONY: read $(READ_C) $(READ_DIR)
+read: check $(READ_C)
+$(READ_C): $(READ_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l \
 	'$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
-$(READ_DIR)::
+$(READ_DIR):
 	@echo "\nStarting read target - Storing json files in: '$@'" && mkdir -p $@
 
 .PHONY: check
-check::
+check:
 	@test -x "$(ROOT_EXE)" || { echo "Could not find root.exe"; exit 1; }
 
 .PHONY: validate

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ dict: check $(DICT_MAKEFILE_DIR)
 $(DICT_MAKEFILE_DIR): $(DICT_DIR)
 	@$(MAKE) -C $@
 $(DICT_DIR):
-	@echo "\nStarting dict target - Storing dictionaries in: '$@'" && mkdir -p $@
+	$(info ###### Starting dict target - Storing dictionaries in: '$@' ######)
+	@mkdir -p $@
 
 # run each write.C file in subdirectories to create .root files
 .PHONY: write $(WRITE_C) $(WRITE_DIR)
@@ -35,7 +36,8 @@ write: check $(WRITE_C)
 $(WRITE_C): $(WRITE_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l '$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root")'
 $(WRITE_DIR):
-	@echo "\nStarting write target - Storing root files in: '$@'" && mkdir -p $@
+	$(info ###### Starting write target - Storing root files in: '$@' ######)
+	@mkdir -p $@
 
 # run each read.C file in subdirectories to create .json files
 .PHONY: read $(READ_C) $(READ_DIR)
@@ -44,7 +46,8 @@ $(READ_C): $(READ_DIR)
 	@LD_LIBRARY_PATH="$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}$(DICT_DIR)" $(ROOT_EXE) -q -l \
 	'$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
 $(READ_DIR):
-	@echo "\nStarting read target - Storing json files in: '$@'" && mkdir -p $@
+	$(info ###### Starting read target - Storing json files in: '$@' ######)
+	@mkdir -p $@
 
 .PHONY: check
 check:
@@ -57,29 +60,25 @@ validate:
     fi
 
 #	run make dict to create dictionaries
-	@echo "-- Creating dictionaries --"
 	@for s_path in $(source_scripts); do \
 		(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) dict dict_dir=\$$ROOT_VERSION") || exit $$?; \
 	done
 
 #	run make write to create binaries
-	@echo "-- Creating binaries --"
 	@for s_path in $(source_scripts); do \
 		(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) write dict_dir=\$$ROOT_VERSION write_dir=\$$ROOT_VERSION") || exit $$?; \
 	done
 	
-#	run make read to create json files
-	@echo "-- Creating .json files --"
+#	run make read to do cross-validation
 	@for s_path in $(source_scripts); do \
 		for w_dir in write/*; do \
 			(bash -c "source $$s_path && ROOT_VERSION=\$$(root-config --version) && $(MAKE) read dict_dir=\$$ROOT_VERSION write_dir=$$(basename $$w_dir) read_dir=\$$ROOT_VERSION") || exit $$?; \
 		done; \
 	done
-	@echo Finished
 
 .PHONY: download
 download: 
-	@echo "Downloading and unpacking assets from GitHub.."
+	$(info Downloading and unpacking assets from GitHub..)
 	@wget -q -N -P ./assets https://github.com/root-project/rntuple-validation/releases/download/v$(ASSET_VERSION)/$(ROOT_ASSET)
 	@mkdir -p write && unzip -n -q -d write/$(basename $(ROOT_ASSET)) assets/$(ROOT_ASSET)
 	@wget -q -N -P ./assets https://github.com/root-project/rntuple-validation/releases/download/v$(ASSET_VERSION)/$(JSON_ASSET)


### PR DESCRIPTION
There was a problem, when adding new write.C files, that the make write target skipped that new file. By marking the targets for the paths as .PHONY, that problem was fixed. In addition, the double ':' could be switched with single ':'.