### PR TITLE
Add test for attributes

### DIFF
--- a/structure/attributes/README.md
+++ b/structure/attributes/README.md
@@ -1,0 +1,15 @@
+# Attributes
+
+## Fields
+
+ * `Int32` (in main RNTuple)
+ * `attr` (in attribute set called `Attributes`)
+
+with each the type `std::int32_t`.
+
+## Entries
+
+1. Associated to the first entry of the main RNTuple
+2. Referring to the second and third entry of the main RNTuple
+
+The values can be found in the reference file `structure.attributes.json`.

--- a/structure/attributes/read.C
+++ b/structure/attributes/read.C
@@ -1,0 +1,43 @@
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RVersion.hxx>
+
+#include <iostream>
+#include <filesystem>
+
+void read(std::string_view input = "structure.attributes.root",
+          std::string_view output = "structure.attributes.json") {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 40, 0)
+  std::cout << "Skipped structure/attributes/read.C - ROOT version too old."
+            << std::endl;
+#else
+  // skipping test if .root file file doesn't exist
+  if (!std::filesystem::exists(input)) {
+    std::cout << "Skipped structure/attributes/read.C - file ('" << input << "') not found" << std::endl;
+    return;
+  }
+  // similar logic as read_structure.hxx
+  std::unique_ptr<ROOT::RNTupleReader> reader = ROOT::RNTupleReader::Open("ntpl", input);
+
+  std::ofstream os(std::string{output});
+  os << "[\n";
+  bool first = true;
+
+  auto attrSet = reader->OpenAttributeSet("Attributes");
+  auto attr = attrSet->GetModel().GetDefaultEntry().GetPtr<std::int32_t>("attr");
+  
+  for (auto attrIdx : attrSet->GetAttributes()) {
+    auto range = attrSet->LoadEntry(attrIdx);
+    if (first) {
+      first = false;
+    } else {
+      os << ",\n";
+    }
+    os << "  {\n";
+    os << "    \"Value\": " << *attr << ",\n";
+    os << "    \"Range\": [" << *range.GetFirst() << ", " << *range.GetLast() << "]\n";
+    os << "  }";
+  }
+
+  os << "\n]\n";
+#endif
+}

--- a/structure/attributes/write.C
+++ b/structure/attributes/write.C
@@ -1,0 +1,42 @@
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RVersion.hxx>
+
+#include <TFile.h>
+#include <cstdint>
+#include <string_view>
+
+void write(std::string_view filename = "structure.attributes.root") {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 40, 0)
+  std::cout << "Skipped structure/attributes/write.C - ROOT version too old."
+            << std::endl;
+#else
+  auto model = ROOT::RNTupleModel::Create();
+  auto Int32 = model->MakeField<std::int32_t>("Int32");
+
+  auto file = std::unique_ptr<TFile>(TFile::Open(std::string(filename).c_str(), "RECREATE"));
+  auto writer = ROOT::RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+  // definition of attribute set with attribute fields
+  auto attrModel = ROOT::RNTupleModel::Create();
+  auto attr = attrModel->MakeField<std::int32_t>("attr");
+  auto attrSet = writer->CreateAttributeSet(std::move(attrModel), "Attributes");
+
+  // first entry
+  auto attrRange = attrSet->BeginRange();
+  *Int32 = 1;
+  writer->Fill();
+  *attr = 1;
+  attrSet->CommitRange(std::move(attrRange));
+
+  // second and third entry
+  attrRange = attrSet->BeginRange();
+  *attr = 2;
+  *Int32 = 2;
+  writer->Fill();
+  *Int32 = 3;
+  writer->Fill();
+  attrSet->CommitRange(std::move(attrRange));
+#endif
+}


### PR DESCRIPTION
Skip write.C for versions that don't support attributes (everything before 6.40) and read.C if binary for attributes doesn't exist.

Closes #69 