### PR TITLE
JSROOT tests for types/fundamental

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ User*.cxx
 *.zip
 *.html
 !template.html
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ JSON_ASSET := Validation-JSON-v$(ASSET_VERSION).zip
 DICT_DIR := $(shell pwd)/dict/$(if $(dict_dir),$(dict_dir)/)
 WRITE_DIR := $(shell pwd)/write/$(if $(write_dir),$(write_dir)/)
 READ_DIR := $(shell pwd)/read/$(if $(write_dir),$(write_dir)/)$(if $(read_dir),$(read_dir)/)
+READ_DIR_JSROOT := $(shell pwd)/read/$(if $(write_dir),$(write_dir)/)jsroot/
 export DICT_DIR
 
 .PHONY: all
@@ -17,9 +18,10 @@ all: check
 	$(MAKE) read
 
 # This assumes there is no whitespace in any of the paths...
-DICT_MAKEFILE_DIR := $(sort $(shell find */ -name Makefile -printf "%h\n"))
+DICT_MAKEFILE_DIR := $(sort $(shell find */ -name Makefile -not -path "node_modules/*" -printf "%h\n"))
 WRITE_C := $(sort $(shell find . -name write.C))
 READ_C := $(sort $(shell find . -name read.C))
+READ_MJS := $(sort $(shell find . -name read.mjs))
 
 # run each Makefile in subdirectories to create dictionaries
 .PHONY: dict $(DICT_MAKEFILE_DIR) $(DICT_DIR)
@@ -47,6 +49,15 @@ $(READ_C): $(READ_DIR)
 	'$@("$(WRITE_DIR)$(subst /,.,$(shell dirname $@)).root", "$(READ_DIR)$(subst /,.,$(shell dirname $@)).json")'
 $(READ_DIR):
 	$(info ###### Starting read target - Storing json files in: '$@' ######)
+	@mkdir -p $@
+
+.PHONY: read_jsroot $(READ_MJS) $(READ_DIR_JSROOT)
+read_jsroot: $(READ_MJS)
+$(READ_MJS): $(READ_DIR_JSROOT)
+	@echo Processing $@
+	@node $@ $(WRITE_DIR)$(subst jsroot.,,$(subst /,.,$(shell dirname $@)).root) $(READ_DIR_JSROOT)$(subst jsroot.,,$(subst /,.,$(shell dirname $@))).json
+$(READ_DIR_JSROOT):
+	$(info  ###### Storing json files created by JSROOT in: '$@' ######)
 	@mkdir -p $@
 
 .PHONY: check

--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ Run `make export_html` to compare the generated `.json` files with each other an
 **Comparison logic**: Each subfolder is assigned a *limiting version*, defined as the smaller of its `write` and `read` versions. A subfolder is only compared against other subfolders whose limiting version is less than or equal to its own.
 
 For example, `read/6.38.00/6.40.00` has a limiting version of `6.38.00` (the smaller of the two). It will be compared against `read/6.36.00/6.36.00` (limiting version `6.36.00` ≤ `6.38.00`), but not against `read/6.40.00/6.40.00` (limiting version `6.40.00` > `6.38.00`).
+
+### Running tests for JSROOT
+To run tests for JSROOT, `nodejs` is required as well as the node-package of JSROOT:
+```
+npm install jsroot
+```
+
+Run `make read_jsroot` to read the generated `.root` files with [JSROOT](https://github.com/root-project/jsroot), a JavaScript library that is capable of reading ROOT files. The supported tests are inside `jsroot`. The resulting `.json` files are stored inside `read/jsroot`.
+
+Run `make write` first to create the `.root` files using the ROOT macros!

--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+
+export function writeJson(dict_input, output, marker=null) {
+    let dict_string = JSON.stringify(dict_input, null, 2);
+    dict_string += "\n"; // read.C macro have an empty new line at the end
+
+    // create folder if not exist and output contains folder path
+    let output_dir = output.split("/").slice(0, -1).join("/");
+    if (output_dir !== "") {
+        if (!existsSync(output_dir)){
+            mkdirSync(output_dir, { recursive: true });
+        }
+    }
+
+    // serialize BigInt as string and then remove the quotation marks, to avoid precision loss of Number()
+    if (marker !== null) {
+        dict_string = dict_string.replace(new RegExp(`"${marker}(-?\\d+)${marker}"`, 'g'),'$1');
+    }
+
+    writeFileSync(output, dict_string);
+}

--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -19,3 +19,36 @@ export function writeJson(dict_input, output, marker=null) {
 
     writeFileSync(output, dict_string);
 }
+
+// convert float to hex representation based on IEEE-754 and C99 standard
+export function floatToHex(num) {
+  if (num === 0) return (Object.is(num, -0) ? "-" : "") + "0x0p+0";
+
+  const buf = new ArrayBuffer(8); // 8 Byte == 64 Bit
+  const view = new DataView(buf);
+  view.setFloat64(0, num, false);
+
+  const bits = view.getBigUint64(0, false); // bitwise operations only work with integer
+  const sign = Number(bits >> 63n); // sign on first bit
+  const rawExp = Number((bits >> 52n) & 0x7ffn); // exponent on next 11 bits
+  const fraction = bits & 0xfffffffffffffn; // fraction on next 52 bits
+
+  let exp, leading, mantBits;
+  if (rawExp === 0) {
+    // check for really small numbers
+    if (fraction === 0n) return (sign ? "-" : "") + "0x0p+0";
+    exp = -1022;
+    leading = "0";
+    mantBits = fraction;
+  } else {
+    exp = rawExp - 1023;
+    leading = "1";
+    mantBits = fraction;
+  }
+
+  let hex = mantBits.toString(16).padStart(13, "0").replace(/0+$/, "");
+  const frac = hex ? "." + hex : "";
+  const expStr = (exp >= 0 ? "+" : "-") + Math.abs(exp);
+
+  return (sign ? "-" : "") + "0x" + leading + frac + "p" + expStr;
+}

--- a/jsroot/types/fundamental/README.md
+++ b/jsroot/types/fundamental/README.md
@@ -3,3 +3,4 @@
  * [`integer`](integer): `[U]Int{8,16,32,64}`, `Split[U]Int{16,32,64}`
  * [`misc`](misc): `Bit`, `Byte`, `Char`
  * [`real`](real): `Real{16,32,64}`, `SplitReal{32,64}`
+ * [`real32trunc`](real32trunc): `Real32Trunc`

--- a/jsroot/types/fundamental/README.md
+++ b/jsroot/types/fundamental/README.md
@@ -1,4 +1,5 @@
 # Fundamental Column Types
 
  * [`integer`](integer): `[U]Int{8,16,32,64}`, `Split[U]Int{16,32,64}`
+ * [`misc`](misc): `Bit`, `Byte`, `Char`
  * [`real`](real): `Real{16,32,64}`, `SplitReal{32,64}`

--- a/jsroot/types/fundamental/README.md
+++ b/jsroot/types/fundamental/README.md
@@ -1,0 +1,3 @@
+# Fundamental Column Types
+
+ * [`integer`](integer): `[U]Int{8,16,32,64}`, `Split[U]Int{16,32,64}`

--- a/jsroot/types/fundamental/README.md
+++ b/jsroot/types/fundamental/README.md
@@ -4,3 +4,7 @@
  * [`misc`](misc): `Bit`, `Byte`, `Char`
  * [`real`](real): `Real{16,32,64}`, `SplitReal{32,64}`
  * [`real32trunc`](real32trunc): `Real32Trunc`
+ * [`real32quant`](real32quant): `Real32Quant`
+
+Note:
+- the columns of `real32quant` are more precise in JSROOT, since JavaScript natively supports double-precision floats

--- a/jsroot/types/fundamental/README.md
+++ b/jsroot/types/fundamental/README.md
@@ -1,3 +1,4 @@
 # Fundamental Column Types
 
  * [`integer`](integer): `[U]Int{8,16,32,64}`, `Split[U]Int{16,32,64}`
+ * [`real`](real): `Real{16,32,64}`, `SplitReal{32,64}`

--- a/jsroot/types/fundamental/integer/read.mjs
+++ b/jsroot/types/fundamental/integer/read.mjs
@@ -1,0 +1,65 @@
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
+import { writeJson } from "../../../jsroot_reader.mjs";
+
+/*
+The following change in rntuple.mjs was necessary to make this test run:
+1. line 910 & 919: remove Number() to avoid rounding of BigInt values
+*/
+
+async function read(
+  input = "types.fundamental.integer.root",
+  output = "types.fundamental.integer.json",
+) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl"),
+    marker = "__BIGINT__"; // used to write BigInts as string in JSON and then convert to number to avoid precision loss
+
+  let dict = [];
+
+  // define fields that exist in .root file
+  const selector = new TSelector(),
+    fields = [
+      "Int8",
+      "UInt8",
+      "Int16",
+      "UInt16",
+      "Int32",
+      "UInt32",
+      "Int64",
+      "UInt64",
+      "SplitInt16",
+      "SplitUInt16",
+      "SplitInt32",
+      "SplitUInt32",
+      "SplitInt64",
+      "SplitUInt64",
+    ];
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        const value = this.tgtobj[field];
+        const res =
+          typeof value === "bigint" ? `${marker}${value}${marker}` : value;
+        subdict[field] = res;
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
+    }
+    dict.push(subdict);
+  };
+
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output, marker);
+}
+
+const [input, output] = process.argv.slice(2);
+read(input, output);

--- a/jsroot/types/fundamental/misc/read.mjs
+++ b/jsroot/types/fundamental/misc/read.mjs
@@ -1,0 +1,44 @@
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
+import { writeJson } from "../../../jsroot_reader.mjs";
+
+async function read(
+  input = "types.fundamental.misc.root",
+  output = "types.fundamental.misc.json",
+) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl");
+  
+  let dict = [];
+
+  // define fields that exist in .root file
+  const selector = new TSelector(),
+    fields = ["Bit", "Byte", "Char"];
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        const value = this.tgtobj[field];
+        const res =
+          typeof value === "string" ? value.codePointAt(0) : Number(value);
+        subdict[field] = res;
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
+    }
+    dict.push(subdict);
+  };
+
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output);
+}
+
+const [input, output] = process.argv.slice(2);
+read(input, output);

--- a/jsroot/types/fundamental/real/read.mjs
+++ b/jsroot/types/fundamental/real/read.mjs
@@ -1,0 +1,51 @@
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
+import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+
+async function read(
+  input = "types.fundamental.real.root",
+  output = "types.fundamental.real.json",
+) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl");
+  
+  let dict = [];
+
+  // define fields that exist in .root file
+  const selector = new TSelector(),
+    fields = [
+      "FloatReal16",
+      "FloatReal32",
+      "DoubleReal16",
+      "DoubleReal32",
+      "DoubleReal64",
+      "FloatSplitReal32",
+      "DoubleSplitReal32",
+      "DoubleSplitReal64",
+    ];
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        const value = this.tgtobj[field];
+        subdict[field] = floatToHex(value);
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
+    }
+    dict.push(subdict);
+  };
+
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output);
+}
+
+const [input, output] = process.argv.slice(2);
+read(input, output);

--- a/jsroot/types/fundamental/real32quant/read.mjs
+++ b/jsroot/types/fundamental/real32quant/read.mjs
@@ -1,0 +1,49 @@
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
+import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+
+async function read(
+  input = "types.fundamental.real32quant.root",
+  output = "types.fundamental.real32quant.json",
+) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl");
+  
+  let dict = [];
+
+  // define fields that exist in .root file
+  const selector = new TSelector(),
+    fields = [
+      "FloatReal32Quant1",
+      "FloatReal32Quant8",
+      "FloatReal32Quant32",
+      "DoubleReal32Quant1",
+      "DoubleReal32Quant20",
+      "DoubleReal32Quant32",
+    ];
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        const value = this.tgtobj[field];
+        subdict[field] = floatToHex(value);
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
+    }
+    dict.push(subdict);
+  };
+
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output);
+}
+
+const [input, output] = process.argv.slice(2);
+read(input, output);

--- a/jsroot/types/fundamental/real32trunc/read.mjs
+++ b/jsroot/types/fundamental/real32trunc/read.mjs
@@ -1,0 +1,49 @@
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
+import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+
+async function read(
+  input = "types.fundamental.real32trunc.root",
+  output = "types.fundamental.real32trunc.json",
+) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl");
+  
+  let dict = [];
+
+  // define fields that exist in .root file
+  const selector = new TSelector(),
+    fields = [
+      "FloatReal32Trunc10",
+      "FloatReal32Trunc16",
+      "FloatReal32Trunc31",
+      "DoubleReal32Trunc10",
+      "DoubleReal32Trunc16",
+      "DoubleReal32Trunc31",
+    ];
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        const value = this.tgtobj[field];
+        subdict[field] = floatToHex(value);
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
+    }
+    dict.push(subdict);
+  };
+
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output);
+}
+
+const [input, output] = process.argv.slice(2);
+read(input, output);

--- a/scripts/cross_validation.py
+++ b/scripts/cross_validation.py
@@ -152,6 +152,10 @@ def get_limiting_version(write_ver: str, read_ver: str) -> Version:
 
     if write_ver.startswith("RNTuple"):
         return Version("0.00.00")
+
+    # currently treating JSROOT as highest version to get a separate column in the HTML
+    if read_ver.startswith("jsroot"):
+        return Version("10.10.10")
     return min(Version(write_ver), Version(read_ver))
 
 def meets_comparison_logic(folder_a: str, folder_b: str) -> bool:


### PR DESCRIPTION
Add JSROOT read scripts for `types/fundamental`

This PR adds corresponding read files that use JSROOT to read the binaries created by the `write.C` files in `types/fundamental`.