### PR TITLE
Refactor JSROOT read function for better readability

### DIFF
--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -1,26 +1,72 @@
-import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { openFile, TSelector } from "jsroot";
+import { rntupleProcess } from "jsroot/rntuple";
 
-export function writeJson(dict_input, output, marker=null) {
-    let dict_string = JSON.stringify(dict_input, null, 2);
-    dict_string += "\n"; // read.C macro have an empty new line at the end
+/**
+ *
+ * @param {string} input - path to input .root file
+ * @param {string} output - path to output .json file
+ * @param {array} fields - list of fields in RNTuple inside input
+ * @param {function} preprocess - optional. function to format entries for JSON serialization
+ * @param {function} args - object containing parameters for preprocess. dict-like object where keys have to match args of preprocess, other than value
+ */
+export async function read(input, output, fields, preprocess, args) {
+  const file = await openFile(input),
+    rntuple = await file.readObject("ntpl");
 
-    // create folder if not exist and output contains folder path
-    let output_dir = output.split("/").slice(0, -1).join("/");
-    if (output_dir !== "") {
-        if (!existsSync(output_dir)){
-            mkdirSync(output_dir, { recursive: true });
+  let dict = [];
+
+  const selector = new TSelector();
+
+  for (const f of fields) {
+    selector.addBranch(f);
+  }
+
+  selector.Process = function (entryIndex) {
+    const subdict = {};
+    for (const field of fields) {
+      try {
+        let value = this.tgtobj[field];
+        if (typeof preprocess === "function") {
+          value = preprocess(value, { ...args, field });
         }
+        subdict[field] = value;
+      } catch (err) {
+        console.error(
+          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
+        );
+      }
     }
+    dict.push(subdict);
+  };
 
-    // serialize BigInt as string and then remove the quotation marks, to avoid precision loss of Number()
-    if (marker !== null) {
-        dict_string = dict_string.replace(new RegExp(`"${marker}(-?\\d+)${marker}"`, 'g'),'$1');
-    }
-
-    writeFileSync(output, dict_string);
+  await rntupleProcess(rntuple, selector);
+  writeJson(dict, output, args);
 }
 
-// convert float to hex representation based on IEEE-754 and C99 standard
+export function writeJson(dict_input, output, { marker } = {}) {
+  let dict_string = JSON.stringify(dict_input, null, 2);
+  dict_string += "\n"; // read.C macro have an empty new line at the end
+
+  // create folder if not exist and output contains folder path
+  let output_dir = output.split("/").slice(0, -1).join("/");
+  if (output_dir !== "") {
+    if (!existsSync(output_dir)) {
+      mkdirSync(output_dir, { recursive: true });
+    }
+  }
+
+  // serialize BigInt as string and then remove the quotation marks, to avoid precision loss of Number()
+  if (marker !== null) {
+    dict_string = dict_string.replace(
+      new RegExp(`"${marker}(-?\\d+)${marker}"`, "g"),
+      "$1",
+    );
+  }
+
+  writeFileSync(output, dict_string);
+}
+
 export function floatToHex(num) {
   if (num === 0) return (Object.is(num, -0) ? "-" : "") + "0x0p+0";
 

--- a/jsroot/types/fundamental/integer/read.mjs
+++ b/jsroot/types/fundamental/integer/read.mjs
@@ -1,65 +1,31 @@
-import { openFile, TSelector } from "jsroot";
-import { rntupleProcess } from "jsroot/rntuple";
-import { writeJson } from "../../../jsroot_reader.mjs";
+import { read } from "../../../jsroot_reader.mjs";
 
 /*
 The following change in rntuple.mjs was necessary to make this test run:
 1. line 910 & 919: remove Number() to avoid rounding of BigInt values
 */
 
-async function read(
-  input = "types.fundamental.integer.root",
-  output = "types.fundamental.integer.json",
-) {
-  const file = await openFile(input),
-    rntuple = await file.readObject("ntpl"),
-    marker = "__BIGINT__"; // used to write BigInts as string in JSON and then convert to number to avoid precision loss
-
-  let dict = [];
-
-  // define fields that exist in .root file
-  const selector = new TSelector(),
-    fields = [
-      "Int8",
-      "UInt8",
-      "Int16",
-      "UInt16",
-      "Int32",
-      "UInt32",
-      "Int64",
-      "UInt64",
-      "SplitInt16",
-      "SplitUInt16",
-      "SplitInt32",
-      "SplitUInt32",
-      "SplitInt64",
-      "SplitUInt64",
-    ];
-
-  for (const f of fields) {
-    selector.addBranch(f);
-  }
-
-  selector.Process = function (entryIndex) {
-    const subdict = {};
-    for (const field of fields) {
-      try {
-        const value = this.tgtobj[field];
-        const res =
-          typeof value === "bigint" ? `${marker}${value}${marker}` : value;
-        subdict[field] = res;
-      } catch (err) {
-        console.error(
-          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
-        );
-      }
-    }
-    dict.push(subdict);
-  };
-
-  await rntupleProcess(rntuple, selector);
-  writeJson(dict, output, marker);
+function checkBigInt(value, { marker }) {
+  const res = typeof value === "bigint" ? `${marker}${value}${marker}` : value;
+  return res;
 }
 
+const fields = [
+  "Int8",
+  "UInt8",
+  "Int16",
+  "UInt16",
+  "Int32",
+  "UInt32",
+  "Int64",
+  "UInt64",
+  "SplitInt16",
+  "SplitUInt16",
+  "SplitInt32",
+  "SplitUInt32",
+  "SplitInt64",
+  "SplitUInt64",
+];
+
 const [input, output] = process.argv.slice(2);
-read(input, output);
+read(input, output, fields, checkBigInt, { marker: "__BIGINT__" }); // marker is used to write BigInts as string in JSON and then convert to number to avoid precision loss

--- a/jsroot/types/fundamental/misc/read.mjs
+++ b/jsroot/types/fundamental/misc/read.mjs
@@ -1,44 +1,11 @@
-import { openFile, TSelector } from "jsroot";
-import { rntupleProcess } from "jsroot/rntuple";
-import { writeJson } from "../../../jsroot_reader.mjs";
+import { read } from "../../../jsroot_reader.mjs";
 
-async function read(
-  input = "types.fundamental.misc.root",
-  output = "types.fundamental.misc.json",
-) {
-  const file = await openFile(input),
-    rntuple = await file.readObject("ntpl");
-  
-  let dict = [];
-
-  // define fields that exist in .root file
-  const selector = new TSelector(),
-    fields = ["Bit", "Byte", "Char"];
-
-  for (const f of fields) {
-    selector.addBranch(f);
-  }
-
-  selector.Process = function (entryIndex) {
-    const subdict = {};
-    for (const field of fields) {
-      try {
-        const value = this.tgtobj[field];
-        const res =
-          typeof value === "string" ? value.codePointAt(0) : Number(value);
-        subdict[field] = res;
-      } catch (err) {
-        console.error(
-          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
-        );
-      }
-    }
-    dict.push(subdict);
-  };
-
-  await rntupleProcess(rntuple, selector);
-  writeJson(dict, output);
+function convertToNum(value) {
+  const res = typeof value === "string" ? value.codePointAt(0) : Number(value);
+  return res;
 }
 
+const fields = ["Bit", "Byte", "Char"];
+
 const [input, output] = process.argv.slice(2);
-read(input, output);
+read(input, output, fields, convertToNum);

--- a/jsroot/types/fundamental/real/read.mjs
+++ b/jsroot/types/fundamental/real/read.mjs
@@ -1,51 +1,15 @@
-import { openFile, TSelector } from "jsroot";
-import { rntupleProcess } from "jsroot/rntuple";
-import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+import { read, floatToHex } from "../../../jsroot_reader.mjs";
 
-async function read(
-  input = "types.fundamental.real.root",
-  output = "types.fundamental.real.json",
-) {
-  const file = await openFile(input),
-    rntuple = await file.readObject("ntpl");
-  
-  let dict = [];
-
-  // define fields that exist in .root file
-  const selector = new TSelector(),
-    fields = [
-      "FloatReal16",
-      "FloatReal32",
-      "DoubleReal16",
-      "DoubleReal32",
-      "DoubleReal64",
-      "FloatSplitReal32",
-      "DoubleSplitReal32",
-      "DoubleSplitReal64",
-    ];
-
-  for (const f of fields) {
-    selector.addBranch(f);
-  }
-
-  selector.Process = function (entryIndex) {
-    const subdict = {};
-    for (const field of fields) {
-      try {
-        const value = this.tgtobj[field];
-        subdict[field] = floatToHex(value);
-      } catch (err) {
-        console.error(
-          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
-        );
-      }
-    }
-    dict.push(subdict);
-  };
-
-  await rntupleProcess(rntuple, selector);
-  writeJson(dict, output);
-}
+const fields = [
+  "FloatReal16",
+  "FloatReal32",
+  "DoubleReal16",
+  "DoubleReal32",
+  "DoubleReal64",
+  "FloatSplitReal32",
+  "DoubleSplitReal32",
+  "DoubleSplitReal64",
+];
 
 const [input, output] = process.argv.slice(2);
-read(input, output);
+read(input, output, fields, floatToHex);

--- a/jsroot/types/fundamental/real32quant/read.mjs
+++ b/jsroot/types/fundamental/real32quant/read.mjs
@@ -1,49 +1,13 @@
-import { openFile, TSelector } from "jsroot";
-import { rntupleProcess } from "jsroot/rntuple";
-import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+import { read, floatToHex } from "../../../jsroot_reader.mjs";
 
-async function read(
-  input = "types.fundamental.real32quant.root",
-  output = "types.fundamental.real32quant.json",
-) {
-  const file = await openFile(input),
-    rntuple = await file.readObject("ntpl");
-  
-  let dict = [];
-
-  // define fields that exist in .root file
-  const selector = new TSelector(),
-    fields = [
-      "FloatReal32Quant1",
-      "FloatReal32Quant8",
-      "FloatReal32Quant32",
-      "DoubleReal32Quant1",
-      "DoubleReal32Quant20",
-      "DoubleReal32Quant32",
-    ];
-
-  for (const f of fields) {
-    selector.addBranch(f);
-  }
-
-  selector.Process = function (entryIndex) {
-    const subdict = {};
-    for (const field of fields) {
-      try {
-        const value = this.tgtobj[field];
-        subdict[field] = floatToHex(value);
-      } catch (err) {
-        console.error(
-          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
-        );
-      }
-    }
-    dict.push(subdict);
-  };
-
-  await rntupleProcess(rntuple, selector);
-  writeJson(dict, output);
-}
+const fields = [
+  "FloatReal32Quant1",
+  "FloatReal32Quant8",
+  "FloatReal32Quant32",
+  "DoubleReal32Quant1",
+  "DoubleReal32Quant20",
+  "DoubleReal32Quant32",
+];
 
 const [input, output] = process.argv.slice(2);
-read(input, output);
+read(input, output, fields, floatToHex);

--- a/jsroot/types/fundamental/real32trunc/read.mjs
+++ b/jsroot/types/fundamental/real32trunc/read.mjs
@@ -1,49 +1,13 @@
-import { openFile, TSelector } from "jsroot";
-import { rntupleProcess } from "jsroot/rntuple";
-import { writeJson, floatToHex } from "../../../jsroot_reader.mjs";
+import { read, floatToHex } from "../../../jsroot_reader.mjs";
 
-async function read(
-  input = "types.fundamental.real32trunc.root",
-  output = "types.fundamental.real32trunc.json",
-) {
-  const file = await openFile(input),
-    rntuple = await file.readObject("ntpl");
-  
-  let dict = [];
-
-  // define fields that exist in .root file
-  const selector = new TSelector(),
-    fields = [
-      "FloatReal32Trunc10",
-      "FloatReal32Trunc16",
-      "FloatReal32Trunc31",
-      "DoubleReal32Trunc10",
-      "DoubleReal32Trunc16",
-      "DoubleReal32Trunc31",
-    ];
-
-  for (const f of fields) {
-    selector.addBranch(f);
-  }
-
-  selector.Process = function (entryIndex) {
-    const subdict = {};
-    for (const field of fields) {
-      try {
-        const value = this.tgtobj[field];
-        subdict[field] = floatToHex(value);
-      } catch (err) {
-        console.error(
-          `ERROR: Failed to read ${field} at entry ${entryIndex}: ${err.message}`,
-        );
-      }
-    }
-    dict.push(subdict);
-  };
-
-  await rntupleProcess(rntuple, selector);
-  writeJson(dict, output);
-}
+const fields = [
+  "FloatReal32Trunc10",
+  "FloatReal32Trunc16",
+  "FloatReal32Trunc31",
+  "DoubleReal32Trunc10",
+  "DoubleReal32Trunc16",
+  "DoubleReal32Trunc31",
+];
 
 const [input, output] = process.argv.slice(2);
-read(input, output);
+read(input, output, fields, floatToHex);


### PR DESCRIPTION
Moving `read`-function from individual tests to `jsroot_reader.mjs` since its almost the same every time. Formating the output for the JSON happens by providing a function to `read`.
