### PR TITLE
JSROOT tests for types/{vector,variant,string}

### DIFF
--- a/jsroot/types/string/read.mjs
+++ b/jsroot/types/string/read.mjs
@@ -1,0 +1,13 @@
+import { read } from "../../jsroot_reader.mjs";
+
+function getUtf8decoding(s) {
+  const bytes = Uint8Array.from(s, (c) => c.charCodeAt(0));
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [input = "types.string.root", output = "types.string.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, getUtf8decoding);

--- a/jsroot/types/variant/read.mjs
+++ b/jsroot/types/variant/read.mjs
@@ -1,0 +1,8 @@
+import { read } from "../../jsroot_reader.mjs";
+
+const fields = ["f", "Vector"];
+
+const [input = "types.variant.root", output = "types.variant.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields);

--- a/jsroot/types/vector/README.md
+++ b/jsroot/types/vector/README.md
@@ -1,0 +1,3 @@
+# `std::vector`
+
+ * [`fundamental`](fundamental): `std::vector<std::int32_t>`

--- a/jsroot/types/vector/README.md
+++ b/jsroot/types/vector/README.md
@@ -1,3 +1,4 @@
 # `std::vector`
 
  * [`fundamental`](fundamental): `std::vector<std::int32_t>`
+ * [`nested`](nested): `std::vector<std::vector<std::int32_t>>`

--- a/jsroot/types/vector/fundamental/read.mjs
+++ b/jsroot/types/vector/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.vector.fundamental.root",
+  output = "types.vector.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields);

--- a/jsroot/types/vector/nested/read.mjs
+++ b/jsroot/types/vector/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.vector.nested.root",
+  output = "types.vector.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields);


### PR DESCRIPTION
Add JSROOT read scripts for:
- `types/vector`
- `types/variant`
- `types/string`

This PR adds the necessary read files that use JSROOT to read the binary files generated by the `write.C` files in the corresponding ROOT tests.