### PR TITLE
JSROOT tests for types/{array,atomic,bitset,tuple}

### DIFF
--- a/jsroot/types/array/read.mjs
+++ b/jsroot/types/array/read.mjs
@@ -1,0 +1,14 @@
+import { read } from "../../jsroot_reader.mjs";
+
+const fields = [
+  "Array_Int32",
+  "Array_Array",
+  "Array_String",
+  "Array_Variant",
+  "Array_Vector",
+];
+
+const [input = "types.array.root", output = "types.array.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields);

--- a/jsroot/types/atomic/read.mjs
+++ b/jsroot/types/atomic/read.mjs
@@ -1,0 +1,29 @@
+import { read, floatToHex } from "../../jsroot_reader.mjs";
+
+function normalizeValue(value, { marker, field }) {
+  if (typeof value === "bigint") return `${marker}${value}${marker}`;
+  if (typeof value === "string") return value.codePointAt(0);
+  if (field.startsWith("Real")) return floatToHex(value, { field });
+  return Number(value);
+}
+
+const fields = [
+  "Bit",
+  "Byte",
+  "Char",
+  "Int8",
+  "UInt8",
+  "Int16",
+  "UInt16",
+  "Int32",
+  "UInt32",
+  "Int64",
+  "UInt64",
+  "Real32",
+  "Real64",
+];
+
+const [input = "types.atomic.root", output = "types.atomic.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, normalizeValue, { marker: "__BIGINT__" });

--- a/jsroot/types/bitset/read.mjs
+++ b/jsroot/types/bitset/read.mjs
@@ -1,0 +1,13 @@
+import { read } from "../../jsroot_reader.mjs";
+
+function bitsetToBinary(val, field) {
+  const n = Number(field.field.replace("Bitset", ""));
+  return BigInt(val).toString(2).padStart(n, "0");
+}
+
+const fields = ["Bitset1", "Bitset64", "Bitset65"];
+
+const [input = "types.bitset.root", output = "types.bitset.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, bitsetToBinary);

--- a/jsroot/types/tuple/read.mjs
+++ b/jsroot/types/tuple/read.mjs
@@ -1,0 +1,19 @@
+import { read } from "../../jsroot_reader.mjs";
+
+function tupleToArray(obj) {
+  const listEntries = [];
+  Object.values(obj).forEach((value) => {
+    if (typeof value === "object") {
+      value = tupleToArray(value);
+    }
+    listEntries.push(value);
+  });
+  return listEntries;
+}
+
+const fields = ["Int32_String_Vector", "Variant", "Tuple", "VectorTuple"];
+
+const [input = "types.tuple.root", output = "types.tuple.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, tupleToArray);


### PR DESCRIPTION
Add JSROOT read scripts for:
- `types/array`
- `types/atomic`
- `types/bitset`
- `types/tuple`

This PR adds the necessary read files that use JSROOT to read the binary files generated by the `write.C` files in the corresponding ROOT tests.