### PR TITLE
JSROOT tests for types/{set,map}

### DIFF
--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -118,3 +118,17 @@ export function sortDeep(obj) {
 
   return obj;
 }
+
+export function pairArrayToMap(arr) {
+  // sort by key
+  arr.sort((a, b) =>
+    String(a.first).localeCompare(String(b.first)),
+  );
+
+  return Object.fromEntries(
+    arr.map((p) => [
+      p.first,
+      Array.isArray(p.second) ? pairArrayToMap(p.second) : p.second,
+    ]),
+  );
+}

--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -98,3 +98,23 @@ export function floatToHex(num) {
 
   return (sign ? "-" : "") + "0x" + leading + frac + "p" + expStr;
 }
+
+export function sortArrayOfNumbers(arr) {
+  return arr.sort((a, b) => a - b);
+}
+
+export function sortDeep(obj) {
+  sortArrayOfNumbers(obj); // sort nums inside array
+
+  obj.forEach((value) => { if (Array.isArray(value)) sortArrayOfNumbers(value); }); // sort elements inside inner array
+
+  obj.sort((a, b) => {
+    const len = Math.min(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+      if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return a.length - b.length;
+  });
+
+  return obj;
+}

--- a/jsroot/types/map/README.md
+++ b/jsroot/types/map/README.md
@@ -1,3 +1,4 @@
 # `std::map`
 
 - [`fundamental`](fundamental): `std::map<std::string, std::int32_t>`
+- [`nested`](nested): `std::map<std::string, std::map<std::string, std::int32_t>>`

--- a/jsroot/types/map/README.md
+++ b/jsroot/types/map/README.md
@@ -1,0 +1,3 @@
+# `std::map`
+
+- [`fundamental`](fundamental): `std::map<std::string, std::int32_t>`

--- a/jsroot/types/map/fundamental/read.mjs
+++ b/jsroot/types/map/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.map.fundamental.root",
+  output = "types.map.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/map/nested/read.mjs
+++ b/jsroot/types/map/nested/read.mjs
@@ -1,0 +1,8 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [input = "types.map.nested.root", output = "types.map.nested.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/multimap/README.md
+++ b/jsroot/types/multimap/README.md
@@ -1,3 +1,4 @@
 # `std::multimap`
 
 - [`fundamental`](fundamental): `std::multimap<std::string, ::int32_t>`
+- [`nested`](nested): `std::multimap<std::string, std::multimap<std::string, std::int32_t>>`

--- a/jsroot/types/multimap/README.md
+++ b/jsroot/types/multimap/README.md
@@ -1,0 +1,3 @@
+# `std::multimap`
+
+- [`fundamental`](fundamental): `std::multimap<std::string, ::int32_t>`

--- a/jsroot/types/multimap/fundamental/read.mjs
+++ b/jsroot/types/multimap/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.multimap.fundamental.root",
+  output = "types.multimap.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/multimap/nested/read.mjs
+++ b/jsroot/types/multimap/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.multimap.nested.root",
+  output = "types.multimap.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/multiset/README.md
+++ b/jsroot/types/multiset/README.md
@@ -1,3 +1,4 @@
 # `std::multiset`
 
  * [`fundamental`](fundamental): `std::multiset<std::int32_t>`
+ * [`nested`](nested): `std::multiset<std::multiset<std::int32_t>>`

--- a/jsroot/types/multiset/README.md
+++ b/jsroot/types/multiset/README.md
@@ -1,0 +1,3 @@
+# `std::multiset`
+
+ * [`fundamental`](fundamental): `std::multiset<std::int32_t>`

--- a/jsroot/types/multiset/fundamental/read.mjs
+++ b/jsroot/types/multiset/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortArrayOfNumbers } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.multiset.fundamental.root",
+  output = "types.multiset.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortArrayOfNumbers);

--- a/jsroot/types/multiset/nested/read.mjs
+++ b/jsroot/types/multiset/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortDeep } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.set.multinested.root",
+  output = "types.multiset.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortDeep);

--- a/jsroot/types/set/README.md
+++ b/jsroot/types/set/README.md
@@ -1,3 +1,4 @@
 # `std::set`
 
  * [`fundamental`](fundamental): `std::set<std::int32_t>`
+ * [`nested`](nested): `std::set<std::set<std::int32_t>>`

--- a/jsroot/types/set/README.md
+++ b/jsroot/types/set/README.md
@@ -1,0 +1,3 @@
+# `std::set`
+
+ * [`fundamental`](fundamental): `std::set<std::int32_t>`

--- a/jsroot/types/set/fundamental/read.mjs
+++ b/jsroot/types/set/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortArrayOfNumbers } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.set.fundamental.root",
+  output = "types.set.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortArrayOfNumbers);

--- a/jsroot/types/set/nested/read.mjs
+++ b/jsroot/types/set/nested/read.mjs
@@ -1,0 +1,8 @@
+import { read, sortDeep } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [input = "types.set.nested.root", output = "types.set.nested.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, sortDeep);

--- a/jsroot/types/unordered_map/README.md
+++ b/jsroot/types/unordered_map/README.md
@@ -1,3 +1,4 @@
 # `std::unordered_map`
 
 - [`fundamental`](fundamental): `std::unordered_map<std::string, std::int32_t>`
+- [`nested`](nested): `std::unordered_map<std::string, std::unordered_map<std::string, std::int32_t>>`

--- a/jsroot/types/unordered_map/README.md
+++ b/jsroot/types/unordered_map/README.md
@@ -1,0 +1,3 @@
+# `std::unordered_map`
+
+- [`fundamental`](fundamental): `std::unordered_map<std::string, std::int32_t>`

--- a/jsroot/types/unordered_map/fundamental/read.mjs
+++ b/jsroot/types/unordered_map/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_map.fundamental.root",
+  output = "types.unordered_map.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/unordered_map/nested/read.mjs
+++ b/jsroot/types/unordered_map/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_map.nested.root",
+  output = "types.unordered_map.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/unordered_multimap/README.md
+++ b/jsroot/types/unordered_multimap/README.md
@@ -1,3 +1,4 @@
 # `std::unordered_map`
 
 - [`fundamental`](fundamental): `std::unordered_map<std::string, std::int32_t>`
+- [`nested`](nested): `std::unordered_map<std::string, std::unordered_map<std::string, std::int32_t>>`

--- a/jsroot/types/unordered_multimap/README.md
+++ b/jsroot/types/unordered_multimap/README.md
@@ -1,0 +1,3 @@
+# `std::unordered_map`
+
+- [`fundamental`](fundamental): `std::unordered_map<std::string, std::int32_t>`

--- a/jsroot/types/unordered_multimap/fundamental/read.mjs
+++ b/jsroot/types/unordered_multimap/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_multimap.fundamental.root",
+  output = "types.unordered_multimap.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/unordered_multimap/nested/read.mjs
+++ b/jsroot/types/unordered_multimap/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, pairArrayToMap } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_multimap.nested.root",
+  output = "types.unordered_multimap.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, pairArrayToMap);

--- a/jsroot/types/unordered_multiset/README.md
+++ b/jsroot/types/unordered_multiset/README.md
@@ -1,0 +1,3 @@
+# `std::unordered_multiset`
+
+ * [`fundamental`](fundamental): `std::unordered_multiset<std::int32_t>`

--- a/jsroot/types/unordered_multiset/README.md
+++ b/jsroot/types/unordered_multiset/README.md
@@ -1,3 +1,4 @@
 # `std::unordered_multiset`
 
  * [`fundamental`](fundamental): `std::unordered_multiset<std::int32_t>`
+ * [`nested`](nested): `std::unordered_multiset<std::unordered_multiset<std::int32_t>>`

--- a/jsroot/types/unordered_multiset/fundamental/read.mjs
+++ b/jsroot/types/unordered_multiset/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortArrayOfNumbers } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_multiset.fundamental.root",
+  output = "types.unordered_multiset.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortArrayOfNumbers);

--- a/jsroot/types/unordered_multiset/nested/read.mjs
+++ b/jsroot/types/unordered_multiset/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortDeep } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_multiset.nested.root",
+  output = "types.unordered_multiset.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortDeep);

--- a/jsroot/types/unordered_set/README.md
+++ b/jsroot/types/unordered_set/README.md
@@ -1,0 +1,3 @@
+# `std::unordered_set`
+
+ * [`fundamental`](fundamental): `std::unordered_set<std::int32_t>`

--- a/jsroot/types/unordered_set/README.md
+++ b/jsroot/types/unordered_set/README.md
@@ -1,3 +1,4 @@
 # `std::unordered_set`
 
  * [`fundamental`](fundamental): `std::unordered_set<std::int32_t>`
+ * [`nested`](nested): `std::unordered_set<std::unordered_set<std::int32_t>>`

--- a/jsroot/types/unordered_set/fundamental/read.mjs
+++ b/jsroot/types/unordered_set/fundamental/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortArrayOfNumbers } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_set.fundamental.root",
+  output = "types.unordered_set.fundamental.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortArrayOfNumbers);

--- a/jsroot/types/unordered_set/nested/read.mjs
+++ b/jsroot/types/unordered_set/nested/read.mjs
@@ -1,0 +1,10 @@
+import { read, sortDeep } from "../../../jsroot_reader.mjs";
+
+const fields = ["Index32", "Index64", "SplitIndex32", "SplitIndex64"];
+
+const [
+  input = "types.unordered_set.nested.root",
+  output = "types.unordered_set.nested.json",
+] = process.argv.slice(2);
+
+read(input, output, fields, sortDeep);


### PR DESCRIPTION
Add JSROOT read scripts for:
- `types/set`
- `types/multiset`
- `types/unordered_set`
- `types/unordered_multiset`
- `types/map`
- `types/multimap`
- `types/unordered_map`
- `types/unordered_multimap`

This PR adds the necessary read files that use JSROOT to read the binary files generated by the `write.C` files in the corresponding ROOT tests.