### PR TITLE
JSROOT tests for structure/{clusters,cluster groups}

### DIFF
--- a/jsroot/structure/cluster_groups/read.mjs
+++ b/jsroot/structure/cluster_groups/read.mjs
@@ -1,0 +1,10 @@
+import { read } from "../../jsroot_reader.mjs";
+
+const fields = [
+  "Int32",
+];
+
+const [input = "structure.cluster_groups.root", output = "structure.cluster_groups.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields);

--- a/jsroot/structure/clusters/read.mjs
+++ b/jsroot/structure/clusters/read.mjs
@@ -1,0 +1,10 @@
+import { read } from "../../jsroot_reader.mjs";
+
+const fields = [
+  "Int32",
+];
+
+const [input = "structure.clusters.root", output = "structure.clusters.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields);


### PR DESCRIPTION
Add JSROOT read scripts for:
- `structure/clusters`
- `structure/cluster_groups`

This PR adds the necessary read files that use JSROOT to read the binary files generated by the `write.C` files in the corresponding ROOT tests.