### PR TITLE
JSROOT Preserve BigInt precision for Int64/UInt64 fields

### DIFF
--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -40,7 +40,7 @@ export async function read(input, output, fields, preprocess, args) {
     dict.push(subdict);
   };
 
-  await rntupleProcess(rntuple, selector);
+  await rntupleProcess(rntuple, selector, { preserveBigInt: true });
   writeJson(dict, output, args);
 }
 


### PR DESCRIPTION
The validation suite specifically processes `Int64`/`UInt64` fields with full precision without interferring with `treeDraw`.