### PR TITLE
JSROOT tests for types/pair and structure/empty

### DIFF
--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -45,7 +45,8 @@ export async function read(input, output, fields, preprocess, args) {
 }
 
 export function writeJson(dict_input, output, { marker } = {}) {
-  let dict_string = JSON.stringify(dict_input, null, 2);
+  let dict_string =
+    dict_input.length === 0 ? "[\n]" : JSON.stringify(dict_input, null, 2);
   dict_string += "\n"; // read.C macro have an empty new line at the end
 
   // create folder if not exist and output contains folder path

--- a/jsroot/structure/empty/read.mjs
+++ b/jsroot/structure/empty/read.mjs
@@ -1,0 +1,8 @@
+import { read } from "../../jsroot_reader.mjs";
+
+const fields = ["Int32"];
+
+const [input = "structure.empty.root", output = "structure.empty.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields);

--- a/jsroot/types/pair/read.mjs
+++ b/jsroot/types/pair/read.mjs
@@ -1,0 +1,15 @@
+import { read } from "../../jsroot_reader.mjs";
+
+function processPair(obj) {
+  if (Array.isArray(obj)) return obj.map(processPair);
+  if (obj && typeof obj === "object")
+    return [processPair(obj.first), obj.second];
+  return obj;
+}
+
+const fields = ["Int32_String", "Variant_Vector", "Pair", "VectorPair"];
+
+const [input = "types.pair.root", output = "types.pair.json"] =
+  process.argv.slice(2);
+
+read(input, output, fields, processPair);


### PR DESCRIPTION
Add JSROOT read scripts for:

- `types/pair`
- `structure/empty`

This PR adds the necessary read files that use JSROOT to read the binary files generated by the write.C files in the corresponding ROOT tests.