### PR TITLE
Extend CI workflow with JSROOT test job

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -17,6 +17,11 @@ on:
         description: 'Run latest LCG nightly build'
         type: boolean
         default: false
+      jsroot_version:
+        description: 'JSROOT Version (leave empty to not run tests)'
+        required: false
+        default: '7.11.1'
+        type: string
 
 jobs:
   cross-validation:
@@ -25,9 +30,10 @@ jobs:
       labels: [self-hosted]
     
     env:
-      # run LCG releases 108, 109 and 110 for each schedules, and 110 for each PR/push
-      VERSIONS: ${{ inputs.versions || (github.event_name == 'schedule' && '108,109,110' || '110') }}
+      VERSIONS: ${{ inputs.versions || (github.event_name == 'schedule' && '108,109,110' || '110') }} # run LCG releases 108, 109 and 110 for each schedules, and 110 for each PR/push
       RUN_DEV3: ${{ inputs.run_dev3 == true || github.event_name == 'schedule' }}
+      JSROOT_SETUP: /cvmfs/sft.cern.ch/lcg/views/LCG_110/x86_64-el9-gcc13-opt/setup.sh
+      JSROOT_VERSION: ${{ inputs.jsroot_version || '~7.11.0' }} # use JSROOT version 7.11.x with newest patch version
 
     container:
       image: gitlab-registry.cern.ch/sft/docker/alma9-core:latest
@@ -59,7 +65,14 @@ jobs:
           fi
           eval "SCRIPTS=(/cvmfs/sft.cern.ch/lcg/views/$PATTERN/x86_64-el9-gcc13-opt/setup.sh)"
           make -j$(nproc) validate source_scripts="${SCRIPTS[*]}"
-        shell: bash         
+        shell: bash
+
+      - name: Run JSROOT tests
+        if: ${{ env.JSROOT_VERSION != '' }}
+        run: |
+          source "$JSROOT_SETUP"
+          npm install "jsroot@$JSROOT_VERSION"
+          make -j$(nproc) validate_jsroot
 
       - name: Create HTML
         run: make export_html

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ $(READ_DIR_JSROOT):
 check:
 	@test -x "$(ROOT_EXE)" || { echo "Could not find root.exe"; exit 1; }
 
+.PHONY: validate_jsroot
+validate_jsroot:
+	@for w_dir in write/*; do \
+	    $(MAKE) read_jsroot write_dir=$$(basename "$$w_dir"); \
+	done
+
 .PHONY: validate
 validate:
 	@if [ "$(source_scripts)" = "" ]; then\

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ npm install jsroot
 Run `make read_jsroot` to read the generated `.root` files with [JSROOT](https://github.com/root-project/jsroot), a JavaScript library that is capable of reading ROOT files. The supported tests are inside `jsroot`. The resulting `.json` files are stored inside `read/jsroot`.
 
 Run `make write` first to create the `.root` files using the ROOT macros!
+
+Run `make validate_jsroot` to read the `.root` files for each subdir in `write/` and store them in subdirs in `read/<subdir>/jsroot`.

--- a/jsroot/jsroot_reader.mjs
+++ b/jsroot/jsroot_reader.mjs
@@ -133,3 +133,12 @@ export function pairArrayToMap(arr) {
     ]),
   );
 }
+
+export function isNewer(current, target) {
+  const [major, minor, patch] = current.split(" ")[0].split(".").map(Number);
+  const [tMajor, tMinor, tPatch] = target.split(".").map(Number);
+  return;
+  major > tMajor ||
+    (major === tMajor && minor > tMinor) ||
+    (major === tMajor && minor === tMinor && patch > tPatch);
+}

--- a/jsroot/structure/cluster_groups/read.mjs
+++ b/jsroot/structure/cluster_groups/read.mjs
@@ -1,10 +1,16 @@
-import { read } from "../../jsroot_reader.mjs";
+import { read, isNewer } from "../../jsroot_reader.mjs";
+import { version } from "jsroot";
 
-const fields = [
-  "Int32",
-];
+if (!isNewer(version, "7.11.1")) {
+  console.log(" -> Skipped structure/cluster_groups: version too low")
+  process.exit();
+}
 
-const [input = "structure.cluster_groups.root", output = "structure.cluster_groups.json"] =
-  process.argv.slice(2);
+const fields = ["Int32"];
+
+const [
+  input = "structure.cluster_groups.root",
+  output = "structure.cluster_groups.json",
+] = process.argv.slice(2);
 
 read(input, output, fields);

--- a/jsroot/structure/empty/read.mjs
+++ b/jsroot/structure/empty/read.mjs
@@ -1,4 +1,10 @@
-import { read } from "../../jsroot_reader.mjs";
+import { read, isNewer } from "../../jsroot_reader.mjs";
+import { version } from "jsroot";
+
+if (!isNewer(version, "7.11.1")) {
+  console.log(" -> Skipped structure/empty: version too low")
+  process.exit();
+}
 
 const fields = ["Int32"];
 

--- a/jsroot/types/fundamental/integer/read.mjs
+++ b/jsroot/types/fundamental/integer/read.mjs
@@ -1,12 +1,14 @@
-import { read } from "../../../jsroot_reader.mjs";
+import { read, isNewer } from "../../../jsroot_reader.mjs";
+import { version } from "jsroot";
 
-/*
-The following change in rntuple.mjs was necessary to make this test run:
-1. line 910 & 919: remove Number() to avoid rounding of BigInt values
-*/
+if (!isNewer(version, "7.11.1")) {
+  console.log(" -> Skipped types/fundamental/integer: version too low")
+  process.exit();
+}
 
 function checkBigInt(value, { marker }) {
-  const res = typeof value === "bigint" ? `${marker}${value}${marker}` : value;
+  const res =
+    typeof value === "bigint" ? `${marker}${value}${marker}` : value;
   return res;
 }
 
@@ -27,7 +29,9 @@ const fields = [
   "SplitUInt64",
 ];
 
-const [input = "types.fundamental.integer.root", output = "types.fundamental.integer.json"] =
-  process.argv.slice(2);
+const [
+  input = "types.fundamental.integer.root",
+  output = "types.fundamental.integer.json",
+] = process.argv.slice(2);
 
 read(input, output, fields, checkBigInt, { marker: "__BIGINT__" }); // marker is used to write BigInts as string in JSON and then convert to number to avoid precision loss

--- a/jsroot/types/fundamental/real32quant/read.mjs
+++ b/jsroot/types/fundamental/real32quant/read.mjs
@@ -1,9 +1,14 @@
-import { read, floatToHex } from "../../../jsroot_reader.mjs";
+import { read, floatToHex, isNewer } from "../../../jsroot_reader.mjs";
+import { version } from "jsroot";
+
+if (!isNewer(version, "7.11.1")) {
+  console.log(" -> Skipped types/fundamental/real32quant: version too low")
+  process.exit();
+}
 
 function formatFloat(num, { field }) {
-  // round num to single-precision float to match the required field precision
   if (field.startsWith("Float")) {
-    num = Math.fround(num);
+    num = Math.fround(num); // round num to single-precision float to match the required field precision
   }
 
   return floatToHex(num);
@@ -18,7 +23,9 @@ const fields = [
   "DoubleReal32Quant32",
 ];
 
-const [input = "types.fundamental.real32quant.root", output = "types.fundamental.real32quant.json"] =
-  process.argv.slice(2);
+const [
+  input = "types.fundamental.real32quant.root",
+  output = "types.fundamental.real32quant.json",
+] = process.argv.slice(2);
 
 read(input, output, fields, formatFloat);


### PR DESCRIPTION
Integrate JSROOT into the cross-validation pipeline. When triggering the workflow manually via `workflow_dispatch`, JSROOT tests can be disabled via a checkbox input.